### PR TITLE
Fixes to CPL_gdalrasterize and CPL_gdalnearblack

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -56,7 +56,8 @@ Rcpp::LogicalVector CPL_gdalrasterize(Rcpp::CharacterVector src, Rcpp::Character
 	GDALRasterizeOptions* opt =  GDALRasterizeOptionsNew(options_char.data(), NULL);
 
 	GDALDatasetH src_pt = GDALOpenEx((const char *) src[0], GDAL_OF_VECTOR | GA_ReadOnly, NULL, NULL, NULL);
-	GDALDatasetH result = GDALRasterize((const char *) dst[0], NULL, src_pt, opt, &err);
+        GDALDatasetH dst_pt = GDALOpen((const char *) dst[0], GA_Update);
+        GDALDatasetH result = GDALRasterize(NULL, dst_pt, src_pt, opt, &err);
 	GDALRasterizeOptionsFree(opt);
 	GDALClose(src_pt);
 	if (result != NULL)
@@ -145,7 +146,7 @@ Rcpp::LogicalVector CPL_gdalnearblack(Rcpp::CharacterVector src, Rcpp::Character
 	GDALNearblackOptions* opt =  GDALNearblackOptionsNew(options_char.data(), NULL);
 
 	// GDALDatasetH src_pt = GDALOpen((const char *) src[0], GA_ReadOnly);
-	GDALDatasetH src_pt = GDALOpenEx((const char *) src[0], GDAL_OF_VECTOR | GA_ReadOnly, NULL, NULL, NULL);
+	GDALDatasetH src_pt = GDALOpenEx((const char *) src[0], GDAL_OF_RASTER | GA_ReadOnly, NULL, NULL, NULL);
 	GDALDatasetH dst_pt = GDALOpen((const char *) dst[0], GA_Update);
 	GDALDatasetH result = GDALNearblack(NULL, dst_pt, src_pt, opt, &err);
 	GDALNearblackOptionsFree(opt);


### PR DESCRIPTION
The fix to CPL_gdalnearblack is +/- self-explanatory: the driver kind
flag needs to communicate that we're needing raster rather than a
vector driver.

The fix to CPL_gdalrasterize reverts a breaking change made in commit
5d23803598f21043ff6ab7d64019cdd66f0cb4e0. That change led to failure
of calls to CPL_gdalrasterize with a message to the effect that "GDAL
Error 1: Attempt to create 0x0 dataset is illegal,sizes must be larger
than zero." My proposed edit repairs that and gets the function
working again.