### PR TITLE
Change one VignetteIndexEntry so each vignette has unique entry

### DIFF
--- a/vignettes/blog1.Rmd
+++ b/vignettes/blog1.Rmd
@@ -6,7 +6,7 @@ output:
     toc: true
     theme: united
 vignette: >
-  %\VignetteIndexEntry{Spatiotemporal tidy arrays for R; first steps}
+  %\VignetteIndexEntry{Spatiotemporal arrays for R; stars blog one}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Before the applying the edit in this pull request, running `vignette(package="stars")` returned two
entries both with the same vignette entry, as shown here:

```
> vignette(package="stars")
Vignettes in package 'stars':

blog1                   Spatiotemporal tidy arrays for R; first steps
                        (source, html)
first                   Spatiotemporal tidy arrays for R; first steps
                        (source, html)
data_model              Stars: data model (source, html)
```