### PR TITLE
apply raster to first two dimensions for regular, rectilinear cases

### DIFF
--- a/R/ncdf.R
+++ b/R/ncdf.R
@@ -83,13 +83,16 @@ read_ncdf = function(.x, ..., var = NULL, ncsub = NULL) {
   ## which coords are regular
   regular = .is_regular(coords)
   if (length(coords) > 1) {
-    if (all(regular[1:2])) {
+   # if (all(regular[1:2])) {
     raster = get_raster(affine = c(0, 0), 
                       dimensions = names(coords)[1:2], curvilinear = FALSE)
-    }
+    #}
     
   }
   dimensions = create_dimensions(dim(out[[1]]), raster)
+  
+  ## if either x, y rectilinear assume both are
+  if (sum(regular[1:2]) == 1) regular[1:2] <- c(FALSE, FALSE)
   for (i in seq_along(coords)) {
     if (regular[i]) {
       dimensions[[i]]$offset[1L] = coords[[i]][ncsub[i, "start"]]
@@ -99,6 +102,7 @@ read_ncdf = function(.x, ..., var = NULL, ncsub = NULL) {
       dimensions[[i]]$values = coords[[i]]
     }
   }
+  
   
   st_stars(out, dimensions)
 }

--- a/R/ncdf.R
+++ b/R/ncdf.R
@@ -92,7 +92,7 @@ read_ncdf = function(.x, ..., var = NULL, ncsub = NULL) {
   dimensions = create_dimensions(dim(out[[1]]), raster)
   
   ## if either x, y rectilinear assume both are
-  if (sum(regular[1:2]) == 1) regular[1:2] <- c(FALSE, FALSE)
+  #if (sum(regular[1:2]) == 1) regular[1:2] <- c(FALSE, FALSE)
   for (i in seq_along(coords)) {
     if (regular[i]) {
       dimensions[[i]]$offset[1L] = coords[[i]][ncsub[i, "start"]]

--- a/R/ncdf.R
+++ b/R/ncdf.R
@@ -4,12 +4,9 @@
 NULL
 
 
-.vec_is_regular <- function(x) {
-  ## no fuzz for now
-  length(unique(diff(x))) == 1
-}
+
 .is_regular <- function(coords_list) {
-  unlist(lapply(coords_list, function(x) .vec_is_regular(x)))
+  unlist(lapply(coords_list, function(x) regular_intervals(x)))
 }
 
 

--- a/R/ncdf.R
+++ b/R/ncdf.R
@@ -100,6 +100,10 @@ read_ncdf = function(.x, ..., var = NULL, ncsub = NULL) {
       dimensions[[i]]$delta[1L]  = mean(diff(coords[[i]]))  
     } else {
       dimensions[[i]]$values = coords[[i]]
+      ## offset/delta for fall-back index (and for NA test )
+      ## https://github.com/r-spatial/stars/blob/master/R/dimensions.R#L294-L303
+      dimensions[[i]]$offset[1L] = 0
+      dimensions[[i]]$delta[1L] = 1  
     }
   }
   

--- a/man/read_ncdf.Rd
+++ b/man/read_ncdf.Rd
@@ -16,9 +16,16 @@ read_ncdf(.x, ..., var = NULL, ncsub = NULL)
 \item{ncsub}{matrix of start, count columns}
 }
 \description{
-read ncdf file into stars object
+Read data from a file using the NetCDF library directly.
 }
 \details{
+The following logic is applied to coordinate axes. If any coordinate axes have 
+regularly spaced coordinates they are reduced to the
+offset/delta form with 'affine = c(0, 0)', otherwise the values of the coordinates
+are stored.   If the data has two or more dimensions and the first two are regular
+they are nominated as the 'raster' for plotting.
+
+
 If `var` is not set the first set of variables on a shared grid is used.
 It's supposed to be the grid with the most dimensions, but there's no control
 yet (see `ncmeta::nc_grids(.x)` for the current assumption). 


### PR DESCRIPTION
This PR nominates the first two dimensions as the raster for `read_ncdf`, if there are two or more dimensions. 

The geotransform logic is applied for regular axes, otherwise it puts the axis coordinates into `values`. 

I've added an internal function `.is_regular` to classify the available coordinate vectors using the existing `regular_intervals`.  

I set affine to `c(0, 0)` which I believe is a fair assumption always for NetCDF. 

Going on the NA test at 
https://github.com/r-spatial/stars/blob/master/R/dimensions.R#L294-L303 

 set `offset= 0, delta = 1` as a fall-back, it seems the gt has to be all non-NA to get the value through to a rectilinear plot. 


