### PR TITLE
Mike ncdf 001

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -138,7 +138,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 		if (length(curvilinear) == 2) {
 			lon = paste0(meta_data$driver[1], ":\"", x, "\":", curvilinear[1])
 			lat = paste0(meta_data$driver[1], ":\"", x, "\":", curvilinear[2])
-			ret = st_as_stars(ret, curvilinear = list(x = read_stars(lon)[[1]], y = read_stars(lat)[[1]]), ...)
+			ret = st_as_stars(ret, curvilinear = list(x = read_stars(lon, RasterIO = RasterIO)[[1]], y = read_stars(lat, RasterIO = RasterIO)[[1]]), ...)
 		}
 		ret
 	}


### PR DESCRIPTION
Two commits, 

* apply the RasterIO subsetting for read_stars in case of `curvilinear`
* apply `curvlinear` arg for `read_ncdf`


Note that NetCDF convention is y-up, so I've flipped from the y-max to match RasterIO. 

```R
## f = normalizePath("~/Git/weird.nc/extdata/get1index_64/test.nc")
f = "test.nc"  ## test.nc from https://github.com/r-spatial/stars/issues/64 
Rio = list(nXOff = 1, nYOff = 1, nXSize = 100, nYSize = 110)
Ncs = cbind(start = c(1, 412 - 110 + 1, 1), count = c(100, 110, 1))

(st  = read_stars(f, curvilinear = c('lon', 'lat'), RasterIO = Rio))
(ns = read_ncdf(f, curvilinear = c("lon", "lat"), ncsub = Ncs))

```

