### PR TITLE
Accept `read_stars()` input outside the working directory

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -61,7 +61,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 		sub = TRUE, quiet = FALSE, NA_value = NA_real_, along = NA_integer_,
 		RasterIO = list(), proxy = FALSE, curvilinear = character(0)) {
 
-	x = .x
+	x = enc2utf8(normalizePath(.x))
 	if (length(x) > 1) { # loop over data sources:
 		ret = lapply(x, read_stars, options = options, driver = driver, sub = sub, quiet = quiet,
 			NA_value = NA_value, RasterIO = as.list(RasterIO), proxy = proxy, curvilinear = curvilinear)


### PR DESCRIPTION
## Summary 

Currently `read_stars()` does not accept input of non-normalized file. Therefore, `normalizePath()` is performed on the input file name.

### ❌ Problem

``` r
library(stars)
#> Loading required package: abind
#> Loading required package: sf
#> Linking to GEOS 3.5.1, GDAL 2.1.2, PROJ 4.9.3

getwd()
#> [1] "/tmp/RtmpgIBAUs/reprex1173a8b189d"
# 1/3: Example code is successful
tif <- 
  system.file("tif/L7_ETMs.tif", package = "stars")
read_stars(tif)
#> stars object with 3 dimensions and 1 attribute
#> attribute(s):
#>   L7_ETMs.tif    
#>  Min.   :  1.00  
#>  1st Qu.: 54.00  
#>  Median : 69.00  
#>  Mean   : 68.91  
#>  3rd Qu.: 86.00  
#>  Max.   :255.00  
#> dimension(s):
#>      from  to  offset delta                       refsys point values
#> x       1 349  288776  28.5 +proj=utm +zone=25 +south... FALSE   NULL
#> y       1 352 9120761 -28.5 +proj=utm +zone=25 +south... FALSE   NULL
#> band    1   6      NA    NA                           NA    NA   NULL

# 2/3: No problem which, input file is exist in working directory.
file.copy(tif, basename(tif))
#> [1] TRUE
read_stars(basename(tif))
#> stars object with 3 dimensions and 1 attribute
#> attribute(s):
#>   L7_ETMs.tif    
#>  Min.   :  1.00  
#>  1st Qu.: 54.00  
#>  Median : 69.00  
#>  Mean   : 68.91  
#>  3rd Qu.: 86.00  
#>  Max.   :255.00  
#> dimension(s):
#>      from  to  offset delta                       refsys point values
#> x       1 349  288776  28.5 +proj=utm +zone=25 +south... FALSE   NULL
#> y       1 352 9120761 -28.5 +proj=utm +zone=25 +south... FALSE   NULL
#> band    1   6      NA    NA                           NA    NA   NULL


# 3/3: However un-successful when input file existing out-of-directory
file.copy(tif, paste0("~/", basename(tif)))
#> [1] FALSE
(new_loc <- 
  paste0("~/", basename(tif)))
#> [1] "~/L7_ETMs.tif"
file.exists(new_loc)
#> [1] TRUE

read_stars(new_loc)
#> trying to read file: ~/L7_ETMs.tif
#> Error in CPL_read_gdal(as.character(x), as.character(options), as.character(driver), : file not found
```

<sup>Created on 2018-11-06 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

### 🔰 Update

``` r
library(stars)
tif <-
  system.file("tif/L7_ETMs.tif", package = "stars")

file.copy(tif, paste0("~/", basename(tif)))
(new_loc <-
  paste0("~/", basename(tif)))
#> [1] "~/L7_ETMs.tif"
file.exists(new_loc)
#> [1] TRUE

read_stars(new_loc)
#> stars object with 3 dimensions and 1 attribute
#> attribute(s):
#>   L7_ETMs.tif    
#>  Min.   :  1.00  
#>  1st Qu.: 54.00  
#>  Median : 69.00  
#>  Mean   : 68.91  
#>  3rd Qu.: 86.00  
#>  Max.   :255.00  
#> dimension(s):
#>      from  to  offset delta                       refsys point values    
#> x       1 349  288776  28.5 +proj=utm +zone=25 +south... FALSE   NULL [x]
#> y       1 352 9120761 -28.5 +proj=utm +zone=25 +south... FALSE   NULL [y]
#> band    1   6      NA    NA                           NA    NA   NULL
```

<sup>Created on 2018-11-06 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

## Related issues

I also add `enc2utf8()` processing for running on windows 

https://github.com/r-spatial/sf/pull/471

 (but I have not been able to verify that this is correct)