### PR TITLE
fix bug in sort_out_along

### DIFF
--- a/R/stars.R
+++ b/R/stars.R
@@ -511,13 +511,15 @@ merge.stars = function(x, y, ...) {
 }
 
 sort_out_along = function(ret) { 
-	d1 = st_dimensions(ret[[1]])
-	d2 = st_dimensions(ret[[2]])
-	if ("time" %in% names(d1) && (isTRUE(d1$time$offset != d2$time$offset) || (d1$time$values != d2$time$values)))
-		"time"
-	else
-		NA_integer_
+  d1 = st_dimensions(ret[[1]])
+  d2 = st_dimensions(ret[[2]])
+  if ("time" %in% names(d1) && 
+      (isTRUE(d1$time$offset != d2$time$offset) || !any(d1$time$values %in% d2$time$values)))
+    "time"
+  else
+    NA_integer_
 }
+
 
 #' @export
 is.na.stars = function(x, ...) {


### PR DESCRIPTION
`sort_out_along` was failing when trying to `c` two `stars` objects with PCICt.
There was also a "bug" for other types of dates as the function used `!=` instead of `!any(x %in% y)`, which I believe is the intention of the code.