### PR TITLE
now use try_as_units so read_stars also produces right units for ecmwf

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -186,7 +186,7 @@ get_data_units = function(data) {
 		units = units[1] # nocov
 	}
 	if (!is.null(units) && nzchar(units))
-		units = try(units::as_units(units), silent = TRUE)
+		units = try_as_units(units)
 	if (inherits(units, "units"))
 		units::set_units(structure(data, units = NULL), units, mode = "standard")
 	else


### PR DESCRIPTION
I noticed the units failed as in #201 for read_stars this should fix it