### PR TITLE
Propagate units in st_apply

### DIFF
--- a/R/ops.R
+++ b/R/ops.R
@@ -127,14 +127,17 @@ st_apply.stars = function(X, MARGIN, FUN, ..., CLUSTER = NULL, PROGRESS = FALSE,
 		{
 			ret <- array(ret,dX)
 		}
-		if(inherits(y,'units')){
-			# calculate function directly on one subset to see what the output units are
-			funUnits<-FUN(do.call('[',c( list(y),ifelse(1:length(dim(y)) %in% MARGIN,1,lapply(dim(y), seq)))))
-			if(inherits(funUnits,'units'))
-				if(all.equal(units(funUnits), units(y))){
-					units(ret) <- units(y)
-				}
-		}
+		# calculate function directly on one subset to see what the output units are
+		ySubset<-do.call('[',c(list(y),
+				       # take the first element for all dimensions in the margin otherwise the full dimension
+				       ifelse(1:length(dim(y)) %in% MARGIN,
+					      1,
+					      lapply(dim(y), seq))
+				       )
+		)
+		funResult<-FUN(ySubset)
+		if(inherits(funResult,'units'))
+				units(ret) <- units(funResult)
 		return(ret)
 	}
 	ret = lapply(X, fn, ...) 

--- a/R/ops.R
+++ b/R/ops.R
@@ -123,10 +123,19 @@ st_apply.stars = function(X, MARGIN, FUN, ..., CLUSTER = NULL, PROGRESS = FALSE,
 				} else
 					parallel::parApply(CLUSTER, X = y, MARGIN = MARGIN, FUN = FUN, ...)
 			}
-		if (is.array(ret))
-			ret
-		else
-			array(ret, dX)
+		if (!is.array(ret))
+		{
+			ret <- array(ret,dX)
+		}
+		if(inherits(y,'units')){
+			# calculate function directly on one subset to see what the output units are
+			funUnits<-FUN(do.call('[',c( list(y),ifelse(1:length(dim(y)) %in% MARGIN,1,lapply(dim(y), seq)))))
+			if(inherits(funUnits,'units'))
+				if(all.equal(units(funUnits), units(y))){
+					units(ret) <- units(y)
+				}
+		}
+		return(ret)
 	}
 	ret = lapply(X, fn, ...) 
 	dim_ret = dim(ret[[1]])

--- a/tests/testthat/test_st_apply.R
+++ b/tests/testthat/test_st_apply.R
@@ -7,6 +7,7 @@ test_that('st_apply retains units', {
 		  X<-st_as_stars(set_units(array(1:27, c(3,3,3)),'m'))
 		  expect_equal(units(X[[1]]), units(st_apply(X, 1:2, mean)[[1]]))
 		  expect_equal(units(X[[1]]), units(st_apply(X, 3, max)[[1]]))
+		  expect_equal(units(log(X[[1]])), units(st_apply(X, 3, function(x) log(sum(x)))[[1]]))
 		  X[['u']]<-array(1:27, c(3,3,3))
 		  expect_equal(units(X[[1]]), units(st_apply(X, 1:2, mean)[[1]]))
 		  expect_equal(units(X[[1]]), units(st_apply(X, 3, max)[[1]]))

--- a/tests/testthat/test_st_apply.R
+++ b/tests/testthat/test_st_apply.R
@@ -1,0 +1,17 @@
+library(testthat)
+library(stars)
+context("st_apply")
+
+
+test_that('st_apply retains units', {
+		  X<-st_as_stars(set_units(array(1:27, c(3,3,3)),'m'))
+		  expect_equal(units(X[[1]]), units(st_apply(X, 1:2, mean)[[1]]))
+		  expect_equal(units(X[[1]]), units(st_apply(X, 3, max)[[1]]))
+		  X[['u']]<-array(1:27, c(3,3,3))
+		  expect_equal(units(X[[1]]), units(st_apply(X, 1:2, mean)[[1]]))
+		  expect_equal(units(X[[1]]), units(st_apply(X, 3, max)[[1]]))
+		  expect_equal(inherits(X[[2]], "units"), inherits(st_apply(X, 1:2, mean)[[2]],'units'))
+		  expect_equal(inherits(X[[2]], "units"), inherits(st_apply(X, 3, max)[[2]],'units'))
+		  expect_false(inherits(st_apply(X, 1:2, function(x) any(is.na(x)))[[1]],'units'))
+		  expect_false(inherits(st_apply(X, 1:2, function(x) any(is.na(x)))[[2]],'units'))
+})


### PR DESCRIPTION
I have created this patch to ensure st_apply to make sure units are retained. I encountered the issue that all units are dropped when using apply functions. I have added test for functions that drop the units or and attributes that do not have units. I tried to be conservative with setting units. This approach fails when `FUN` changes the units. One could alternatively just assign the output units of `FUN`
 