### PR TITLE
tidync is not used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,6 @@ Suggests:
     spacetime,
     starsdata,
     testthat,
-    tidync,
     viridis,
     xts,
     zoo


### PR DESCRIPTION
A tiny thing: tidync is in Suggests but isn't required at all currently 