### PR TITLE
add "inner" to what in st_join

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -68,7 +68,7 @@ st_intersects.stars = function(x, y, sparse = TRUE, ..., as_points = NA, transpo
 #' @param join the join function, which should return an sgbp object; see details
 #' @param ... arguments that will be passed on to the join function
 #' @param as_points logical; controls whether grid cells in \code{x} will be treated as points, or as cell areas; the \link{st_intersects.stars} method by default will derive this from \code{x}'s metadata, or else assume areas.
-#' @param what either "left1" or "right"
+#' @param what "left1", "right" or "inner"; see details
 #' @param warn logical; if TRUE, warn on 1-to-many matches when \code{what} is \code{"left1"}
 #' @return If what is "left1", an object of class stars with the (first) value of y at spatial instances of x
 #' @details When there is more than one match to a single x value, the first matching record from y is taken (and if \code{warn} is TRUE a warning is raised). If what is "inner", an object of class \code{sf} with all matching records of x and y.


### PR DESCRIPTION
According to the details (and the source code), there is an "inner" option for `st_join.stars()`. I also have just used the "inner" option successfully which is why I also have updated the documentation accordingly.