### PR TITLE
stars default geotransform from GDAL strategy

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -1,4 +1,4 @@
-maybe_normalizePath = function(.x, np = FALSE) { 
+maybe_normalizePath = function(.x, np = FALSE) {
 	prefixes = c("NETCDF:", "HDF5:", "HDF4:", "HDF4_EOS:")
 	has_prefix = function(pf, x) substr(x, 1, nchar(pf)) == pf
 	if (!np || any(sapply(prefixes, has_prefix, x = .x)))
@@ -27,12 +27,12 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' @return object of class \code{stars}
 #' @details In case \code{.x} contains multiple files, they will all be read and combined with \link{c.stars}. Along which dimension, or how should objects be merged? If \code{along} is set to \code{NA} it will merge arrays as new attributes if all objects have identical dimensions, or else try to merge along time if a dimension called \code{time} indicates different time stamps. A single name (or positive value) for \code{along} will merge along that dimension, or create a new one if it does not already exist. If the arrays should be arranged along one of more dimensions with values (e.g. time stamps), a named list can passed to \code{along} to specify them; see example.
 #'
-#' \code{RasterIO} is a list with zero or more of the following named arguments: 
-#' \code{nXOff}, \code{nYOff} (both 1-based: the first row/col has offset value 1), 
+#' \code{RasterIO} is a list with zero or more of the following named arguments:
+#' \code{nXOff}, \code{nYOff} (both 1-based: the first row/col has offset value 1),
 #' \code{nXSize}, \code{nYSize}, \code{nBufXSize}, \code{nBufYSize}, \code{bands}, code{resample}.
 #' see https://www.gdal.org/classGDALDataset.html#a80d005ed10aefafa8a55dc539c2f69da for their meaning;
 #' \code{bands} is an integer vector containing the band numbers to be read (1-based: first band is 1)
-#' Note that if \code{nBufXSize} or \code{nBufYSize} are specified for downsampling an image, 
+#' Note that if \code{nBufXSize} or \code{nBufYSize} are specified for downsampling an image,
 #' resulting in an adjusted geotransform. \code{resample} reflects the resampling method and
 #' has to be one of: "nearest_neighbour" (the default),
 #' "bilinear", "cubic", "cubic_spline", "lanczos", "average", "mode", or "Gauss".
@@ -47,7 +47,7 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' t1 = as.Date("2018-07-31")
 #' # along is a named list indicating two dimensions:
 #' read_stars(c(tif, tif, tif, tif), along = list(foo = c("bar1", "bar2"), time = c(t1, t1+2)))
-#' 
+#'
 #' m = matrix(1:120, nrow = 12, ncol = 10)
 #' dim(m) = c(x = 10, y = 12) # named dim
 #' st = st_as_stars(m)
@@ -57,7 +57,7 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' tmp = tempfile(fileext = ".tif")
 #' write_stars(st, tmp)
 #' (red <- read_stars(tmp))
-#' read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXsize = 10, nYSize = 12, 
+#' read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXsize = 10, nYSize = 12,
 #'    nBufXSize = 2, nBufYSize = 2))[[1]]
 #' (red <- read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXsize = 10, nYSize = 12,
 #'    nBufXSize = 2, nBufYSize = 2)))
@@ -68,9 +68,9 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' plot(st_as_sfc(st_as_stars(st), as_points = FALSE), add = TRUE, border = 'grey')
 #' plot(st_as_sfc(red, as_points = FALSE), add = TRUE, border = 'green', lwd = 2)
 #' file.remove(tmp)
-read_stars = function(.x, ..., options = character(0), driver = character(0), 
+read_stars = function(.x, ..., options = character(0), driver = character(0),
 		sub = TRUE, quiet = FALSE, NA_value = NA_real_, along = NA_integer_,
-		RasterIO = list(), proxy = FALSE, curvilinear = character(0), 
+		RasterIO = list(), proxy = FALSE, curvilinear = character(0),
 		normalize_path = TRUE, RAT = character(0)) {
 
 	x = if (is.list(.x)) {
@@ -78,11 +78,11 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 			rapply(.x, f, classes = "character", how = "replace", np = normalize_path)
 		} else
 			enc2utf8(maybe_normalizePath(.x, np = normalize_path))
-	
+
 	if (length(curvilinear) == 2 && is.character(curvilinear)) {
-		lon = adrop(read_stars(.x, sub = curvilinear[1], driver = driver, quiet = quiet, NA_value = NA_value, 
+		lon = adrop(read_stars(.x, sub = curvilinear[1], driver = driver, quiet = quiet, NA_value = NA_value,
 			RasterIO = RasterIO, ...))
-		lat = adrop(read_stars(.x, sub = curvilinear[2], driver = driver, quiet = quiet, NA_value = NA_value, 
+		lat = adrop(read_stars(.x, sub = curvilinear[2], driver = driver, quiet = quiet, NA_value = NA_value,
 			RasterIO = RasterIO, ...))
 		curvilinear = setNames(c(st_set_dimensions(lon, c("x", "y")), st_set_dimensions(lat, c("x", "y"))), c("x", "y"))
 	}
@@ -95,9 +95,13 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 		return(do.call(c, append(ret, list(along = along))))
 	}
 
-	data = sf::gdal_read(x, options = options, driver = driver, read_data = !proxy, 
+	data = sf::gdal_read(x, options = options, driver = driver, read_data = !proxy,
 		NA_value = NA_value, RasterIO_parameters = as.list(RasterIO))
-
+	if (data$default_geotransform == 1) {
+	  ## we have the 0 1 0 0 0 1 transform indicated
+	  ## so stars policy is flip-y and shift to be in 0, ncol, 0, nrow
+	  data$geotransform <- c(0, 1, 0, data$rows[2L], 0, -1)
+	}
 	if (length(data$bands) == 0) { # read sub-datasets: different attributes
 		sub_names = split_strings(data$sub) # get named list
 		sub_datasets = sub_names[seq(1, length(sub_names), by = 2)]
@@ -114,7 +118,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 		.read_stars = function(x, options, driver, quiet, proxy, curvilinear) {
 			if (! quiet)
 				cat(paste0(tail(strsplit(x, ":")[[1]], 1), ", "))
-			read_stars(x, options = options, driver = driver, NA_value = NA_value, 
+			read_stars(x, options = options, driver = driver, NA_value = NA_value,
 				RasterIO = as.list(RasterIO), proxy = proxy, curvilinear = curvilinear)
 		}
 
@@ -123,7 +127,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 			else
 				data$driver[1]
 
-		ret = lapply(sub_datasets, .read_stars, options = options, 
+		ret = lapply(sub_datasets, .read_stars, options = options,
 			driver = driver, quiet = quiet, proxy = proxy, curvilinear = curvilinear)
 		if (! quiet)
 			cat("\n")
@@ -142,7 +146,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 				get_data_units(attr(data, "data")) # extract data array; sets units if present
 		if (meta_data$driver[1] == "netCDF")
 			meta_data = parse_netcdf_meta(meta_data, x) # sets all kind of units
-		if (! proxy && !is.null(meta_data$units) && !is.na(meta_data$units) 
+		if (! proxy && !is.null(meta_data$units) && !is.na(meta_data$units)
 				&& !inherits(data, "units")) # set units
 			units(data) = try_as_units(meta_data$units)
 		meta_data = parse_gdal_meta(meta_data)
@@ -150,7 +154,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 		newdims = lengths(meta_data$dim_extra)
 		if (length(newdims) && !proxy)
 			dim(data) = c(dim(data)[1:2], newdims)
-				
+
 		ct = meta_data$color_tables
 		if (!proxy && any(lengths(ct) > 0)) {
 			ct = ct[[ which(length(ct) > 0)[1] ]]
@@ -166,16 +170,16 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 		}
 
 		dims = if (proxy) {
-				if (length(meta_data$bands) > 1) 
-					c(x = meta_data$cols[2], 
-					  y = meta_data$rows[2], 
+				if (length(meta_data$bands) > 1)
+					c(x = meta_data$cols[2],
+					  y = meta_data$rows[2],
 					  band = length(meta_data$bands),
 					  lengths(meta_data$dim_extra))
 				else
-					c(x = meta_data$cols[2], 
-					  y = meta_data$rows[2], 
+					c(x = meta_data$cols[2],
+					  y = meta_data$rows[2],
 					  lengths(meta_data$dim_extra))
-			} else 
+			} else
 				NULL
 
 		### WAS: tail(strsplit(x, .Platform$file.sep)[[1]], 1)
@@ -187,7 +191,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 		else
 			st_stars(setNames(list(data), tail(strsplit(x, '[\\\\/:]+')[[1]], 1)),
 				create_dimensions_from_gdal_meta(dim(data), meta_data))
-		
+
 		if (is.list(curvilinear))
 			st_as_stars(ret, curvilinear = curvilinear, ...)
 		else


### PR DESCRIPTION
Here's what I think stars should do, and that `sf::gdal_read()` should return the default geotransform as-is (0 1 0 0 0 1). 

The y-negation puts an image in the correct orientation, but (weirdly) below y = 0 clashing with the default `st_as_stars(matrix)` which is cleanly `bbox(xmin = 0, ymin = 0, xmin = ncol, xmax = nrow)`. We can do the shift (above y = 0) in sf as well, but I think that's presumptuous for a "read with GDAL function". 

This way, `gdal_read()` does what GDAL says it should do (return default geotransform) and tools that use that function can make their own choice without having to unpick a stars-targetted interpretation. 

Apologies for not supplying this along with https://github.com/r-spatial/sf/pull/1307 it was intended to go together. 


