### PR TITLE
condition default_geotransform check on sf version

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -97,7 +97,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 
 	data = sf::gdal_read(x, options = options, driver = driver, read_data = !proxy,
 		NA_value = NA_value, RasterIO_parameters = as.list(RasterIO))
-	if (data$default_geotransform == 1) {
+	if (packageVersion("sf") >= "0.9-0" && data$default_geotransform == 1) {
 	  ## we have the 0 1 0 0 0 1 transform indicated
 	  ## so stars policy is flip-y and shift to be in 0, ncol, 0, nrow
 	  data$geotransform <- c(0, 1, 0, data$rows[2L], 0, -1)

--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -1,0 +1,13 @@
+test_that("default geotransform works", {
+  f <- file.path(R.home(), "Tcl/lib/tk8.6/images/logo100.gif")
+  st <- read_stars(f)
+
+  if (packageVersion("sf") >= "0.9-0") {
+    expect_true(all(!is.na(unlist(unclass(st_dimensions(st)$x)[c("offset", "delta")]))))
+
+  } else {
+    expect_equal(unlist(unclass(st_dimensions(st)$x)[c("offset", "delta")]),
+                 c(offset = NA_real_, delta = NA_real_))
+
+  }
+})


### PR DESCRIPTION
Added a version check, since only sf>=0.9-0 has "default_transform" property. 