### PR TITLE
Add RStudio project

### DIFF
--- a/stars.Rproj
+++ b/stars.Rproj
@@ -1,0 +1,21 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: No
+NumSpacesForTab: 4
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: XeLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Thank you for response in #266. This is the PR for addressing issues.

I've made it the same as [the sf repository](https://github.com/r-spatial/sf/blob/92deac30b80f3898e37f15435d3659dcc61836f2/sf.Rproj) for options.  

Ignoring `.Rproj` and related files had already been done by 79ac735bcfe37a73bd9e7aefa401f3994ae05a37.

