### PR TITLE
add where argument and examples to st_get_dimension_values()

### DIFF
--- a/R/dimensions.R
+++ b/R/dimensions.R
@@ -128,12 +128,38 @@ st_set_dimensions = function(.x, which, values = NULL, point = NULL, names = NUL
 
 
 #' @name st_dimensions
+#' @param where character, one of 'start', 'center' or 'end'. Set to NA (default) to ignore and use \code{max} and \code{center} explictly.  This argument provides a convenient alternative to setting \code{max} and \code{center}.
 #' @param max logical; if \code{TRUE} return the end, rather than the beginning of an interval
 #' @param center logical; if \code{TRUE} return the center of an interval; if \code{NA} return the center for raster dimensions, and the start of intervals in other cases
 #' @export
-st_get_dimension_values = function(.x, which, ..., max = FALSE, center = NA) {
+#' @examples
+#' m = matrix(1:20, nrow = 5, ncol = 4)
+#' dim(m) = c(x = 5, y = 4) # named dim
+#' (s = st_as_stars(m))
+#' st_get_dimension_values(s, 'x', where = "start")
+#' st_get_dimension_values(s, 'x', center = FALSE)
+#' st_get_dimension_values(s, 'x', where = "center")
+#' st_get_dimension_values(s, 'x', center = TRUE)
+#' st_get_dimension_values(s, 'x', where = "end")
+#' st_get_dimension_values(s, 'x', max = TRUE)
+st_get_dimension_values = function(.x, which, ..., where = NA, max = FALSE, center = NA) {
 	if ((!is.numeric(which) && !is.character(which)) || length(which) != 1)
 		stop("argument which should be a length 1 dimension index or name") # nocov
+  if (!is.na(where)){
+    w = tolower(where[1])
+    if (w == 'center'){
+      max = FALSE
+      center = TRUE
+    } else if (w == 'start'){
+      max = FALSE
+      center = FALSE
+    } else if (w == 'end'){
+      max = TRUE
+      center = NA
+    } else {
+      stop("where, if not NA, must be 'start', 'center' or 'end': ", where)
+    }
+  }
 	expand_dimensions(.x, ..., max = max, center = center)[[which]]
 }
 

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -34,8 +34,7 @@
   attr = 1,
   asp = NULL,
   rgb = NULL,
-  maxColorValue = ifelse(inherits(rgb, "data.frame"), 255, max(x[[attr]], na.rm =
-    TRUE)),
+  maxColorValue = ifelse(inherits(rgb, "data.frame"), 255, max(x[[attr]], na.rm = TRUE)),
   xlab = if (!axes) "" else names(d)[1],
   ylab = if (!axes) "" else names(d)[2],
   xlim = st_bbox(extent)$xlim,

--- a/man/st_dimensions.Rd
+++ b/man/st_dimensions.Rd
@@ -34,7 +34,7 @@ st_set_dimensions(
   ...
 )
 
-st_get_dimension_values(.x, which, ..., max = FALSE, center = NA)
+st_get_dimension_values(.x, which, ..., where = NA, max = FALSE, center = NA)
 }
 \arguments{
 \item{.x}{object to retrieve dimensions information from}
@@ -56,6 +56,10 @@ st_get_dimension_values(.x, which, ..., max = FALSE, center = NA)
 \item{names}{character; new names vector for (all) dimensions, ignoring \code{which}}
 
 \item{xy}{length-2 character vector; (new) names for the \code{x} and \code{y} raster dimensions}
+
+\item{where}{character one of 'start', 'center' or 'end'. Set to NA to ignore
+and use \code{max} and \code{center} explictly.  This argument provides
+a convenient alternative to setting \code{max} and \code{center}}
 
 \item{max}{logical; if \code{TRUE} return the end, rather than the beginning of an interval}
 
@@ -83,4 +87,13 @@ rbind(c(0.45,0.515), c(0.525,0.605), c(0.63,0.69), c(0.775,0.90), c(1.55,1.75), 
    names = "bandwidth_midpoint", point = TRUE))
 # set bandwidth intervals:
 (x3 = st_set_dimensions(x, "band", values = make_intervals(bw), names = "bandwidth"))
+m = matrix(1:20, nrow = 5, ncol = 4)
+dim(m) = c(x = 5, y = 4) # named dim
+(s = st_as_stars(m))
+st_get_dimension_values(s, 'x', where = "start")
+st_get_dimension_values(s, 'x', center = FALSE)
+st_get_dimension_values(s, 'x', where = "center")
+st_get_dimension_values(s, 'x', center = TRUE)
+st_get_dimension_values(s, 'x', where = "end")
+st_get_dimension_values(s, 'x', max = TRUE)
 }

--- a/man/stars_subset.Rd
+++ b/man/stars_subset.Rd
@@ -66,4 +66,11 @@ image(x[buf])
 plot(buf, add = TRUE, col = NA)
 image(x[buf, crop=FALSE])
 plot(buf, add = TRUE, col = NA)
+lc = read_stars(system.file("tif/lc.tif", package = "stars"))
+x = c(orig = lc, 
+      flip_x = st_flip(lc, "x"), 
+      flip_y = st_flip(lc, "y"), 
+      flip_xy = st_flip(lc, c("x", "y")), 
+      along = 3)
+plot(x)
 }


### PR DESCRIPTION
Would it be helpful to provide an optional single argument to specify the location of dimension values?  This request adds a `where` argument to manage the values of `center` and `max`, but by default doesn't mess with them.

```
library(stars)
#> Loading required package: abind
#> Loading required package: sf
#> Warning: package 'sf' was built under R version 3.6.2
#> Linking to GEOS 3.7.2, GDAL 2.4.2, PROJ 5.2.0
m = matrix(1:20, nrow = 5, ncol = 4)
dim(m) = c(x = 5, y = 4) # named dim
(s = st_as_stars(m))
#> stars object with 2 dimensions and 1 attribute
#> attribute(s):
#>       A1        
#>  Min.   : 1.00  
#>  1st Qu.: 5.75  
#>  Median :10.50  
#>  Mean   :10.50  
#>  3rd Qu.:15.25  
#>  Max.   :20.00  
#> dimension(s):
#>   from to offset delta refsys point values    
#> x    1  5      0     1     NA FALSE   NULL [x]
#> y    1  4      0     1     NA FALSE   NULL [y]
st_get_dimension_values(s, 'x', where = "start")
#> [1] 0 1 2 3 4
st_get_dimension_values(s, 'x', center = FALSE)
#> [1] 0 1 2 3 4
st_get_dimension_values(s, 'x', where = "center")
#> [1] 0.5 1.5 2.5 3.5 4.5
st_get_dimension_values(s, 'x', center = TRUE)
#> [1] 0.5 1.5 2.5 3.5 4.5
st_get_dimension_values(s, 'x', where = "end")
#> [1] 1 2 3 4 5
st_get_dimension_values(s, 'x', max = TRUE)
#> [1] 1 2 3 4 5
```