### PR TITLE
Refer to st_mosaic() in raster vignette

### DIFF
--- a/vignettes/raster-stars-mapping.Rmd
+++ b/vignettes/raster-stars-mapping.Rmd
@@ -59,7 +59,7 @@ tribble(
 tribble(
   ~raster, ~stars, ~`Note/comment`,
   "merge", "c", "#, currently only works for adjacent objects",
-  "mosaic", "", "?",
+  "mosaic", "st_mosaic", "",
   "crop", "filter, st_crop", "",
   "setExtent", "", "# maybe use st_warp?",
   "trim", "", "#",


### PR DESCRIPTION
I believe `st_mosaic()` is a equivalent to `mosaic()`.