### PR TITLE
fix read_stars for driver not well recognized

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -75,7 +75,7 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' file.remove(tmp)
 read_stars = function(.x, ..., options = character(0), driver = character(0),
 		sub = TRUE, quiet = FALSE, NA_value = NA_real_, along = NA_integer_,
-		RasterIO = list(), proxy = !length(curvilinear) && is_big(.x, sub = sub, ...), 
+		RasterIO = list(), proxy = !length(curvilinear) && is_big(.x, sub = sub, driver=driver, ...), 
 		curvilinear = character(0), normalize_path = TRUE, RAT = character(0)) {
 
 	x = if (is.list(.x)) {


### PR DESCRIPTION
I had a case for which the raster file in ENVI format was not well recognised by sf::gdal_read. However, the data was well read with sf::gdal_read inputting a predefined driver='ENVI'. However, as `proxy` is now defined throw `is_big` in the signature, but without forwarding the driver. And `is_big` is calling read_stars thus leading to a wrong detection of the driver leading to an error in my case. Forwarding the driver to is_big in the proxy definition of read_stars signature is avoiding such a behavior.