### PR TITLE
fix st_rgb for ndims > 3

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -442,20 +442,25 @@ contour.stars = function(x, ...) {
 #' if (require(ggplot2)) {
 #'  ggplot() + geom_stars(data = r) + scale_fill_identity()
 #' }
-st_rgb = function(x, dimension = 3, use_alpha = FALSE, maxColorValue = 255L, probs = c(0., 1.)) {
+st_rgb = function(x, dimension = 3, use_alpha = FALSE, maxColorValue = 255L, stretch = FALSE, probs = c(0., 1.)) {
 	if (is.character(dimension))
 		dimension = match(dimension, names(dim(x)))
 	stopifnot(is.numeric(dimension), length(dimension)==1)
 	dims = setdiff(seq_along(dim(x)), dimension)
-	cutoff = function(x, probs) {
-		qs = quantile(x, probs, na.rm = TRUE)
-		x = (x - qs[1])/(qs[2] - qs[1])
-		x[x > 1] = 1
+	cutoff = function(x, maxColorValue, stretch, probs) {
+		if(stretch){
+			qs = quantile(x, probs, na.rm = TRUE)
+			x = (x - qs[1])/(qs[2] - qs[1])
+			x * maxColorValue
+		}
+		x[x > maxColorValue] = maxColorValue
 		x[x < 0] = 0
-		x * maxColorValue
+
 	}
-	y = st_apply(x, dimension, cutoff, probs = probs)
+	
+	y = st_apply(x, dimension, cutoff, maxColorValue = maxColorValue, stretch = stretch, probs = probs)
 	x = aperm(y, sapply(names(dim(x)), function(z) which(names(dim(y))==z)))
+		
 	rgb4 = function(x, ...) if (any(is.na(x[1:4]))) NA_character_ else rgb(x[1], x[2], x[3], x[4], ...)
 	rgb3 = function(x, ...) if (any(is.na(x[1:3]))) NA_character_ else rgb(x[1], x[2], x[3], ...)
 	if (use_alpha)

--- a/R/plot.R
+++ b/R/plot.R
@@ -454,8 +454,8 @@ st_rgb = function(x, dimension = 3, use_alpha = FALSE, maxColorValue = 255L, pro
 		x[x < 0] = 0
 		x * maxColorValue
 	}
-	if (any(probs != c(0.,1.)))
-		x = st_apply(x, dimension, cutoff, probs = probs)
+	y = st_apply(x, dimension, cutoff, probs = probs)
+	x = aperm(y, sapply(names(dim(x)), function(z) which(names(dim(y))==z)))
 	rgb4 = function(x, ...) if (any(is.na(x[1:4]))) NA_character_ else rgb(x[1], x[2], x[3], x[4], ...)
 	rgb3 = function(x, ...) if (any(is.na(x[1:3]))) NA_character_ else rgb(x[1], x[2], x[3], ...)
 	if (use_alpha)


### PR DESCRIPTION
This patch fixes 2 bugs:
- cutoff is not applied when probs=c(0, 1) leading to an error if values are more than maxColorValue. I think it should be applied in any case.
- st_apply flips dimensions to c(no_margins, MARGIN) leading to an application on wrong dimension of rgb3 or rgb4 after application of cutoff. Thus, it should be permuted back to the original dimension order after st_apply of cutoff.
Example: when ndims is more than 3, e.g. {x, y, band, date}, after st_apply of cutoff on dimension 3, dimensions become {x, y, date, band} thus dimension=3 corresponds to date, not anymore to band.

This last comment leads to an st_apply concern: why would it permute the dimensions when using a function leading to same dimensions as original? example:
```
tif = system.file("tif/L7_ETMs.tif", package = "stars")
x = read_stars(tif)
st_apply(x, 2, function(x) x)
```
It will lead to dimensions {x, band, y}. Shouldn't it be the same as the original {x, y, band}? If yes, I have a fix for that as well and it would remove the second bug mentioned above by the way. You tell me :-)