### PR TITLE
fix st_apply to keep original dim order

### DIFF
--- a/R/ops.R
+++ b/R/ops.R
@@ -147,10 +147,14 @@ st_apply.stars = function(X, MARGIN, FUN, ..., CLUSTER = NULL, PROGRESS = FALSE,
 			if (length(no_margin) > 1 && dim(ret[[1]])[1] == prod(dim_no_margin)) {
 				r = attr(st_dimensions(X), "raster")
 				new_dim = c(dim_no_margin, dim(ret[[1]])[-1])
-				for (i in seq_along(ret))
+				perm_dim = sort(c(no_margin, MARGIN), index.return = TRUE)$ix
+				for (i in seq_along(ret)){
 					dim(ret[[i]]) = new_dim
+					# permute back to original dimensions
+					ret[[i]] = aperm(ret[[i]], perm_dim)
+				}
 				# set dims:
-				dims = st_dimensions(X)[c(no_margin, MARGIN)]
+				dims = st_dimensions(X)
 			} else {
 				orig = st_dimensions(X)[MARGIN]
 				r = attr(orig, "raster")


### PR DESCRIPTION
This fix is the one mentioned in PR #340 
Why would st_apply permute the dimensions when using a function leading to same dimensions as original? example:
```
tif = system.file("tif/L7_ETMs.tif", package = "stars")
x = read_stars(tif)
st_apply(x, 2, function(x) x)
```
will lead to dimensions {x, band, y}. 
With that type of functions, the fix proposed permutes back to the same dimensions as the original, here {x, y, band}.

I couldn't think of any situation in which it would enter that `if (length(no_margin) > 1 && dim(ret[[1]])[1] == prod(dim_no_margin))` other than when it has the same dimensions as the original, but maybe you should double check.