### PR TITLE
CI: install new pkgdown reqs

### DIFF
--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -87,7 +87,7 @@ jobs:
         run: sudo apt install libcurl4-openssl-dev
 
       - name: "[Custom} [Stage] [Linux] Install pkgdown system lib req"
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.config.r == 'release'
         run: sudo apt install libharfbuzz-dev libfribidi-dev
 
       - name: "[Custom block] Install spatial libraries"

--- a/.github/workflows/tic.yml
+++ b/.github/workflows/tic.yml
@@ -86,6 +86,10 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt install libcurl4-openssl-dev
 
+      - name: "[Custom} [Stage] [Linux] Install pkgdown system lib req"
+        if: runner.os == 'Linux'
+        run: sudo apt install libharfbuzz-dev libfribidi-dev
+
       - name: "[Custom block] Install spatial libraries"
         if: runner.os == 'Linux'
         run: sudo apt install libgdal-dev libproj-dev libgeos-dev libudunits2-dev netcdf-bin

--- a/.github/workflows/update-tic.yml
+++ b/.github/workflows/update-tic.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: "[Stage] Dependencies"
         run: |
-            sudo apt install libcurl4-openssl-dev libsodium-dev
+            sudo apt install libcurl4-openssl-dev libsodium-dev libharfbuzz-dev libfribidi-dev
             Rscript -e "if (!requireNamespace('remotes')) install.packages('remotes', type = 'source')"
             Rscript -e "remotes::install_github('ropensci/tic', dependencies = TRUE)"
 


### PR DESCRIPTION
By default {tic] uses the macOS runner for building pkgdown which does not require system libs because it uses binary packages.

On Linux however (which is used in this repo), the new system lib requirements of {ragg} (pkgdown dep) need to be installed by hand.