### PR TITLE
Ensure attribute names of file-based raster are retained in st_as_stars.Raster

### DIFF
--- a/R/raster.R
+++ b/R/raster.R
@@ -50,7 +50,9 @@ st_as_stars.Raster = function(.x, ..., att = 1, ignore_file = FALSE) {
 				attr(r, "dimensions")[[dxy[1]]] = dimx
 				attr(r, "dimensions")[[dxy[2]]] = dimy
 
-				names(r) <- names(.x)
+				if (inherits(.x, "RasterLayer"))
+					names(r) <- names(.x)
+
 				return(r)
 			}
 

--- a/R/raster.R
+++ b/R/raster.R
@@ -50,6 +50,7 @@ st_as_stars.Raster = function(.x, ..., att = 1, ignore_file = FALSE) {
 				attr(r, "dimensions")[[dxy[1]]] = dimx
 				attr(r, "dimensions")[[dxy[2]]] = dimy
 
+				names(r) <- names(.x)
 				return(r)
 			}
 

--- a/tests/testthat/test_st_as_stars.R
+++ b/tests/testthat/test_st_as_stars.R
@@ -1,53 +1,68 @@
 context("st_as_stars tests")
 
+options(rgdal_show_exportToProj4_warnings = "none")
+
 test_that("basic st_as_stars", {
   skip_on_os("solaris")
 
   f <- system.file("nc/timeseries.nc", package = "stars")
-  
+
   test_list <- ncdfgeom::read_timeseries_dsg(f)
-  
+
   stars_obj <- st_as_stars(test_list)
-  
+
   expect_true("XYZ" %in% class(st_dimensions(stars_obj)$points$values[[1]]))
-  
+
   expect_s3_class(stars_obj, "stars")
-  
+
   dim <- stars::st_dimensions(stars_obj)
   #expect_true(sf::st_crs(dim$points$refsys) == sf::st_crs(4326))
   expect_equal(dim$time$refsys, "POSIXct")
-  
+
   expect_s3_class(dim$points$values, "sfc_POINT")
-  
-  expect_true(dim$points$point)  
-  
+
+  expect_true(dim$points$point)
+
   geom_point <- sf::st_as_sf(data.frame(id = names(test_list$data_frames[[1]]),
                                         lon = test_list$lons,
-                                        lat = test_list$lats, stringsAsFactors = FALSE), 
+                                        lat = test_list$lats, stringsAsFactors = FALSE),
                              coords = c("lon", "lat"), crs = 4326)
-  
+
   geom_poly <- sf::st_buffer(st_transform(geom_point, 3857), dist = 100)
-  
+
   stars_obj <- st_as_stars(test_list, sf_geometry = geom_poly)
-  
+
   dim <- stars::st_dimensions(stars_obj)
-  expect_equal(sf::st_crs(dim$geometry$refsys)$proj4string, 
+  expect_equal(sf::st_crs(dim$geometry$refsys)$proj4string,
                sf::st_crs(geom_poly)$proj4string)
-  
+
   expect_s3_class(dim$geometry$values, "sfc_POLYGON")
-  expect_false(dim$geometry$point)  
-  
+  expect_false(dim$geometry$point)
+
   stars_obj <- st_as_stars(test_list, sf_geometry = geom_point)
   dim <- stars::st_dimensions(stars_obj)
-  
-  expect_equal(sf::st_crs(dim$geometry$refsys)$proj4string, 
+
+  expect_equal(sf::st_crs(dim$geometry$refsys)$proj4string,
                sf::st_crs(geom_point)$proj4string)
-  expect_true(dim$geometry$point)  
+  expect_true(dim$geometry$point)
   expect_s3_class(dim$geometry$values, "sfc_POINT")
-  
+
   test_list$alts <- numeric(0)
-  
+
   stars_obj <- st_as_stars(test_list)
-  
+
   expect_true("XY" %in% class(st_dimensions(stars_obj)$points$values[[1]]))
+})
+
+test_that("st_as_stars.Raster", {
+  tif = system.file("tif/L7_ETMs.tif", package = "stars")
+  x = raster::raster(tif)
+  stars_obj <- st_as_stars(x)
+  expect_s3_class(st_as_stars(x), "stars")
+  expect_equal(names(stars_obj), names(x))
+
+  # change the name of the attribute
+  names(x) <- "newname"
+  stars_obj2 <- st_as_stars(x)
+  expect_equal(names(stars_obj2), names(x))
 })

--- a/tests/testthat/test_st_as_stars.R
+++ b/tests/testthat/test_st_as_stars.R
@@ -58,7 +58,7 @@ test_that("st_as_stars.Raster", {
   tif = system.file("tif/L7_ETMs.tif", package = "stars")
   x = raster::raster(tif)
   stars_obj <- st_as_stars(x)
-  expect_s3_class(st_as_stars(x), "stars")
+  expect_s3_class(stars_obj, "stars")
   expect_equal(names(stars_obj), names(x))
 
   # change the name of the attribute


### PR DESCRIPTION
Currently if you run `st_as_stars()` on a file-based `Raster` object, the names are lost (if they have been modified):

``` r
library(stars)

tif = system.file("tif/L7_ETMs.tif", package = "stars")
x = raster::raster(tif)
stars_obj <- st_as_stars(x)
names(stars_obj)
#> [1] "L7_ETMs.tif"

# change the name of the attribute
names(x) <- "newname"
stars_obj2 <- st_as_stars(x)
# New name is not retained
names(stars_obj2)
#> [1] "L7_ETMs.tif"
```

This PR retains the names of the `Raster` object in the newly-created `stars` object (and adds a simple test).

<sup>Created on 2020-11-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>