### PR TITLE
fix 'nXsize' arg name

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -19,8 +19,8 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' @param NA_value numeric value to be used for conversion into NA values; by default this is read from the input file
 #' @param along length-one character or integer, or list; determines how several arrays are combined, see Details.
 #' @param RasterIO list with named parameters for GDAL's RasterIO, to further control the extent, resolution and bands to be read from the data source; see details.
-#' @param proxy logical; if \code{TRUE}, an object of class \code{stars_proxy} is read which contains array 
-#' metadata only; if \code{FALSE} the full array data is read in memory. Always \code{FALSE} for curvilinear girds. 
+#' @param proxy logical; if \code{TRUE}, an object of class \code{stars_proxy} is read which contains array
+#' metadata only; if \code{FALSE} the full array data is read in memory. Always \code{FALSE} for curvilinear girds.
 #' If not set, defaults to \code{TRUE} when the number of cells to be read is larger than \code{options(stars.n_proxy},
 #' or to 1e8 if that option was not set.
 #' @param curvilinear length two character vector with names of subdatasets holding longitude and latitude values for all raster cells, or named length 2 list holding longitude and latitude matrices; the names of this list should correspond to raster dimensions referred to
@@ -60,9 +60,9 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' tmp = tempfile(fileext = ".tif")
 #' write_stars(st, tmp)
 #' (red <- read_stars(tmp))
-#' read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXsize = 10, nYSize = 12,
+#' read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXSize = 10, nYSize = 12,
 #'    nBufXSize = 2, nBufYSize = 2))[[1]]
-#' (red <- read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXsize = 10, nYSize = 12,
+#' (red <- read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXSize = 10, nYSize = 12,
 #'    nBufXSize = 2, nBufYSize = 2)))
 #' red[[1]] # cell values of subsample grid:
 #' \dontrun{
@@ -75,7 +75,7 @@ maybe_normalizePath = function(.x, np = FALSE) {
 #' file.remove(tmp)
 read_stars = function(.x, ..., options = character(0), driver = character(0),
 		sub = TRUE, quiet = FALSE, NA_value = NA_real_, along = NA_integer_,
-		RasterIO = list(), proxy = !length(curvilinear) && is_big(.x, sub = sub, driver=driver, ...), 
+		RasterIO = list(), proxy = !length(curvilinear) && is_big(.x, sub = sub, driver=driver, ...),
 		curvilinear = character(0), normalize_path = TRUE, RAT = character(0)) {
 
 	x = if (is.list(.x)) {
@@ -237,7 +237,7 @@ read_stars = function(.x, ..., options = character(0), driver = character(0),
 #' @export
 #' @name read_stars
 #' @param x object to be read with \link{read_stars}
-#' @param n_proxy integer; number of cells above which .x will be read as stars 
+#' @param n_proxy integer; number of cells above which .x will be read as stars
 #' proxy object, i.e. not as in-memory arrays but left on disk
 is_big = function(x, ..., sub = sub, n_proxy = options("stars.n_proxy")[[1]] %||% 1.e8) {
 	prod(dim(read_stars(x, ..., sub = sub, proxy = TRUE, quiet = TRUE))) > n_proxy

--- a/man/read_stars.Rd
+++ b/man/read_stars.Rd
@@ -42,8 +42,8 @@ is_big(x, ..., sub = sub, n_proxy = options("stars.n_proxy")[[1]] \%||\% 1e+08)
 
 \item{RasterIO}{list with named parameters for GDAL's RasterIO, to further control the extent, resolution and bands to be read from the data source; see details.}
 
-\item{proxy}{logical; if \code{TRUE}, an object of class \code{stars_proxy} is read which contains array 
-metadata only; if \code{FALSE} the full array data is read in memory. Always \code{FALSE} for curvilinear girds. 
+\item{proxy}{logical; if \code{TRUE}, an object of class \code{stars_proxy} is read which contains array
+metadata only; if \code{FALSE} the full array data is read in memory. Always \code{FALSE} for curvilinear girds.
 If not set, defaults to \code{TRUE} when the number of cells to be read is larger than \code{options(stars.n_proxy},
 or to 1e8 if that option was not set.}
 
@@ -55,7 +55,7 @@ or to 1e8 if that option was not set.}
 
 \item{x}{object to be read with \link{read_stars}}
 
-\item{n_proxy}{integer; number of cells above which .x will be read as stars 
+\item{n_proxy}{integer; number of cells above which .x will be read as stars
 proxy object, i.e. not as in-memory arrays but left on disk}
 }
 \value{
@@ -97,9 +97,9 @@ st
 tmp = tempfile(fileext = ".tif")
 write_stars(st, tmp)
 (red <- read_stars(tmp))
-read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXsize = 10, nYSize = 12,
+read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXSize = 10, nYSize = 12,
    nBufXSize = 2, nBufYSize = 2))[[1]]
-(red <- read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXsize = 10, nYSize = 12,
+(red <- read_stars(tmp, RasterIO = list(nXOff = 1, nYOff = 1, nXSize = 10, nYSize = 12,
    nBufXSize = 2, nBufYSize = 2)))
 red[[1]] # cell values of subsample grid:
 \dontrun{


### PR DESCRIPTION
There was the wrong argument name ("_nXsize_") in the `read_stars` function. Should be "_nXSize_".