### PR TITLE
proper driver for grd file extension

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -144,7 +144,7 @@ detect.driver = function(filename) { #nocov start
 		switch(ext, 
 			tif  = ,
 			tiff = 'GTiff',
-			grd  = 'raster',
+			grd  = 'rraster',
 			asc  = 'ascii',
 			nc   = ,
 			cdf  = ,


### PR DESCRIPTION
Hi @edzer , 

when detecting the driver to be used from a filename extension, if `.grd` is being used, the driver should be `rraster` instead of `raster`, this PR fixes this (so it adds on `r` :)).

