### PR TITLE
Direct readers to (terra} for non-data cubes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -35,6 +35,8 @@ This R package provides classes and methods for reading,
 manipulating, plotting and writing such data cubes, to the extent
 that there are proper formats for doing so.
 
+If your raster datasets are *not* data cubes but instead isolated raster layers use [`terra`](https://github.com/rspatial/terra). Please note that `terra` replaces the older `raster` package.
+
 ## Raster and vector data cubes
 
 The canonical data cube most of us have in mind is that where two


### PR DESCRIPTION
Until [recently](https://twitter.com/TimSalabim3/status/1349705933321068544?s=20) I was under the impression that {stars} was a replacement (and improvement) upon the {raster} package. Tim Salabim was kind enough to correct me that {terra} will replace {raster}.

I only have my experience to go on, but I feel this is a reasonable mistake to make based on the current documentation and that the [Task View doesn't mention {terra}](https://github.com/r-spatial/task_views/issues/17).

As a non-GIS expert my phrasing of "isolated raster layers" is more than likely incorrect. I'd be pleased to receive comments on this PR and to propose additional changes throughout the repo.