### PR TITLE
Fix error in reading from geopackage containing multiple rasters

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -1,5 +1,5 @@
 maybe_normalizePath = function(.x, np = FALSE) {
-	prefixes = c("NETCDF:", "HDF5:", "HDF4:", "HDF4_EOS:", "SENTINEL2_L1", "SENTINEL2_L2")
+	prefixes = c("NETCDF:", "HDF5:", "HDF4:", "HDF4_EOS:", "SENTINEL2_L1", "SENTINEL2_L2", "GPKG:")
 	has_prefix = function(pf, x) substr(x, 1, nchar(pf)) == pf
 	if (!np || any(sapply(prefixes, has_prefix, x = .x)))
 		.x


### PR DESCRIPTION
Currently, at least on my Windows 10 machine, attempts to read a
raster from a geopackage containing multiple layers fail as shown
below.

This PR solves the problem for me. I don't fully grasp how
`read_stars()` works, though, nor the role of `maybe_normalizePath()`,
so the PR will need a quick glance to make sure that it doesn't break
the function in other important corner cases.

Here is a reproducible example that demonstrates the issue. After
incorporating my suggested edit to `maybe_normalizePath()`, all of the
calls to `read_stars()` work as expected.

```r
library(stars)

## Write two layers to single geopackage
x <- read_stars(system.file("tif/L7_ETMs.tif", package = "stars"))
write_stars(st_as_stars(x[,,,1]), "example.gpkg", driver = "GPKG",
            options = c("RASTER_TABLE=layer1"))
write_stars(st_as_stars(x[,,,2]), "example.gpkg", driver = "GPKG",
            options = c("RASTER_TABLE=layer2", "APPEND_SUBDATASET=YES"))

## Attempts to read a layer from the newly created geopackage fail

read_stars("example.gpkg")
## trying to read file: c:\Users\Josh\Desktop\GPKG:C:\Users\Josh\Desktop\example.gpkg:layer1
## Error in CPL_read_gdal(as.character(x), as.character(options), as.character(driver),  :
##   file not found

read_stars("example.gpkg", sub = "layer1", quiet = TRUE)
## trying to read file: c:\Users\Josh\Desktop\GPKG:example.gpkg:layer1
## Error in CPL_read_gdal(as.character(x), as.character(options), as.character(driver),  :
##   file not found

read_stars("example.gpkg", sub = "layer1", quiet = TRUE, normalize_path = FALSE)
## trying to read file: c:\Users\Josh\Desktop\GPKG:C:\Users\Josh\Desktop\example.gpkg:layer1
## Error in CPL_read_gdal(as.character(x), as.character(options), as.character(driver),  :
##   file not found
```