### PR TITLE
.get_dims error in read_ncdf for non-standard X,Y,Z or T dimensions

### DIFF
--- a/R/ncdf.R
+++ b/R/ncdf.R
@@ -349,18 +349,18 @@ read_ncdf = function(.x, ..., var = NULL, ncsub = NULL, curvilinear = character(
   if(length(dim_matcher) < 2) {
     dim_matcher <- c(dim_matcher,
                      axis[axis$variable == c_v$Y, ]$dimension)
-  } else if(nrow(dims) == 4 & !c_v$curvilinear) {
-    z_axis <- unique(axis[!axis$variable %in% c(c_v$X, c_v$Y, c_v$T) &
-                            !axis$dimension %in% dim_matcher & 
-                            axis$dimension != -1, ]$dimension)
   }
 
   z_axis <- integer(0)
   if(!is.na(c_v$Z)) {
     z_axis <- axis[axis$variable == c_v$Z, ]$dimension
     dim_matcher <- c(dim_matcher, z_axis)
+  } else if(nrow(dims) == 4 & !c_v$curvilinear) {
+    z_axis <- unique(axis[!axis$variable %in% c(c_v$X, c_v$Y, c_v$T) &
+                            !axis$dimension %in% dim_matcher &
+                            axis$dimension != -1, ]$dimension)
   }
-  
+
   if(!is.na(c_v$T)) {
     t_axis <- axis[axis$variable == c_v$T, ]$dimension
     if(length(z_axis) > 1) {

--- a/R/ncdf.R
+++ b/R/ncdf.R
@@ -355,11 +355,8 @@ read_ncdf = function(.x, ..., var = NULL, ncsub = NULL, curvilinear = character(
   if(!is.na(c_v$Z)) {
     z_axis <- axis[axis$variable == c_v$Z, ]$dimension
     dim_matcher <- c(dim_matcher, z_axis)
-  } else if(nrow(dims) == 4 & !c_v$curvilinear) {
-    z_axis <- unique(axis[!axis$variable %in% c(c_v$X, c_v$Y, c_v$T) &
-                            !axis$dimension %in% dim_matcher, ]$dimension)
   }
-
+  
   if(!is.na(c_v$T)) {
     t_axis <- axis[axis$variable == c_v$T, ]$dimension
     if(length(z_axis) > 1) {

--- a/R/ncdf.R
+++ b/R/ncdf.R
@@ -349,6 +349,10 @@ read_ncdf = function(.x, ..., var = NULL, ncsub = NULL, curvilinear = character(
   if(length(dim_matcher) < 2) {
     dim_matcher <- c(dim_matcher,
                      axis[axis$variable == c_v$Y, ]$dimension)
+  } else if(nrow(dims) == 4 & !c_v$curvilinear) {
+    z_axis <- unique(axis[!axis$variable %in% c(c_v$X, c_v$Y, c_v$T) &
+                            !axis$dimension %in% dim_matcher & 
+                            axis$dimension != -1, ]$dimension)
   }
 
   z_axis <- integer(0)


### PR DESCRIPTION
When reading a netcdf with `read_ncdf`, it seems there is a bug in `.get_dims` trying to access a -1 dimension index, i.e. an NA dimension index in axis output of ncmeta:
```
Error in seq.default(dims$start[ic], length = dims$count[ic]) : 
  'length.out' must be a non-negative number
```

In my case it occured loading a netcdf generated with python xarray, which adds a `spatial_ref` coordinate dimension that only has CRS attributes but hasn't got any variable depending on it (variables only depend on x , y, band, time). In that particular case `ncmeta::nc_meta(.x)` outputs an axis that has NA as a dimension index:
```
head(ncmeta::nc_meta(.x)$axis, 20)
# A tibble: 20 x 3
    axis variable    dimension
   <int> <chr>           <int>
 1     1 band                1
 2     2 confirmed           3
 3     3 confirmed           2
 4     4 confirmed           1
 5     5 confirmed           0
...
14    14 possible            3
15    15 possible            2
16    16 possible            1
17    17 possible            0
18    18 spatial_ref        NA
19    19 time                0
20    20 x                   3
```
The NA is immediatly replaced by -1 within `.fix_meta` (netcdf.R line 69):
```
meta <- .fix_meta(ncmeta::nc_meta(.x))
```
Then an error occures trying to access this -1 index within .get_dims.

I narrowed the error to the evaluation of z_axis, which has an `else if` statement, i.e. if not a Z axis then make all dimensions other than X, Y or T a Z axis (line :
```
z_axis <- integer(0)
  if(!is.na(c_v$Z)) {
    z_axis <- axis[axis$variable == c_v$Z, ]$dimension
    dim_matcher <- c(dim_matcher, z_axis)
  } else if(nrow(dims) == 4 & !c_v$curvilinear) {
    z_axis <- unique(axis[!axis$variable %in% c(c_v$X, c_v$Y, c_v$T) &
                            !axis$dimension %in% dim_matcher, ]$dimension)
  }
```
I am not sure why this `else if` chunk shouldn't be removed:
- I understand that it could be to identify Z axis that was not identified with ncmeta, but is there any reason to do that even if it has nothing to do with Z axis?
- moreover, if one coordinate is NA (i.e. a coordinate not used), it is beforeward converted to -1, thus appearing in the `else if unique` statement of above code
- moreover, at the end of `.get_dims` there is also another chunk of code buzzing me:
```
if(all(!is.na(dim_matcher))) { # it will always happen, as NAs have been replaced previously by -1 in .fix_meta
    if(length(dim_matcher) != length(dims$id)) { # it will never happen as all dimensions other than X, Y, T are included in z_axis
      dim_matcher <- c(dim_matcher,
                       dims$id[!dims$id %in% dim_matcher])
      dim_matcher <- unique(dim_matcher)
    }
    dims <- dims[match(dims$id, dim_matcher), ] # it will make an error with any -1 dimension, i.e. NA at the output of ncmeta
    dims$axis <- canon_order[1:nrow(dims)]
  }
```
In this PR I fixed the error removing the `else if` chunk of z_axis. Maybe you have any reason/use case where it should be kept?

There is still this `if(all(!is.na(dim_matcher)))` that seems useless as the NA have been replace by -1 in .fix_meta. So maybe an if(all(dim_matcher != -1)) would be more appropriate?

Sorry for the long PR, it is quite a special case, although it concerns xarray output compatibility which may be useful for many users.
I did not included any example file, please tell me if needed.