### PR TITLE
fix bug for rasterizing data.frame with more than xy

### DIFF
--- a/R/rasterize.R
+++ b/R/rasterize.R
@@ -125,7 +125,7 @@ st_as_stars.data.frame = function(.x, ..., dims = coords, xy = dims[1:2], y_decr
 					create_dimension(values = suv, is_raster = TRUE)
 			this_dim = this_dim + 1
 		}
-		names(dimensions) = names(.x)[xy]
+		names(dimensions) = names(.x)[dims]
 	
 		raster_xy = if (length(xy) == 2) names(.x)[xy] else c(NA_character_, NA_character_)
 		d = create_dimensions(dimensions, raster = get_raster(dimensions = raster_xy))


### PR DESCRIPTION
@edzer, since your last commit 497762d , when rasterizing a data.frame with dimensions {x, y, time} for example it leads to an error as time dimension name is set to NA:
```
Error in if (any(names(lst) == "")) { : 
  missing value where TRUE/FALSE needed
```
I modified back one line to fix this bug.