### PR TITLE
fix wrong offset assignement for non-raster dimensions

### DIFF
--- a/R/rasterize.R
+++ b/R/rasterize.R
@@ -136,7 +136,7 @@ st_as_stars.data.frame = function(.x, ..., dims = coords, xy = dims[1:2], y_decr
 			dimensions[[this_dim]] = if (inherits(v, "sfc"))
 					create_dimension(values = v[match(uv, dig)])
 				else
-					create_dimension(values = suv, is_raster = TRUE)
+					create_dimension(values = suv, is_raster = i %in% xy)
 			this_dim = this_dim + 1
 		}
 		names(dimensions) = names(.x)[dims]


### PR DESCRIPTION
When converting data.frame with xy and numeric but non raster dimensions (e.g. date), the create_dimension considers these non-raster dimensions as raster dimensions setting an offset=value[1]-0.5*delta because of systematic flag is_raster=TRUE when values are regularly distributed.
Filtering on that non-raster dimension is not possible anymore unless taking into account the 0.5*delta either with st_get_dimension_values(center=T) or manually on the other side, or resetting the dimension to its original value after st_as_stars. Same operation is also needed to keep the right values when faceting plot.

Wouldn't it make sens to dedicate is_raster flag only to raster dimensions, i.e. xy given by user?

This would allow to keep the original values of these non-raster dimensions and simplify further operations. 
It is the proposal of this PR