### PR TITLE
Stretching methods for st_rgb()

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -534,10 +534,10 @@ st_rgb <- function (x,
 			structure(ret, dim = dim(g))
 		}
 	} else {
-		rgb4 = function(r, g, b, a) structure(rgb(r, g, b, a,
-												  maxColorValue = maxColorValue), dim = dim(r))
-		rgb3 = function(r, g, b) structure(rgb(r, g, b, maxColorValue = maxColorValue),
-										   dim = dim(r))
+		rgb4 = function(r, g, b, a)
+			structure(rgb(r, g, b, a,maxColorValue = maxColorValue), dim = dim(r))
+		rgb3 = function(r, g, b)
+			structure(rgb(r, g, b, maxColorValue = maxColorValue), dim = dim(r))
 	}
 	st_apply(x, dims, if (use_alpha) rgb4 else rgb3)
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -487,7 +487,8 @@ st_rgb <- function (x,
 			x = stats::ecdf(x)(x)
 			x * maxColorValue
 		} else {
-			x
+			qs = range(x)
+			(x - qs[1])/(qs[2] - qs[1]) * maxColorValue
 		}
 	}
 
@@ -499,16 +500,14 @@ st_rgb <- function (x,
 	if(is.logical(stretch)) {
 		if(stretch){
 			stretch.method = "percent"
-			message("Stretch as logical == TRUE, then percent clip by probs is applied")
 		} else {
-			maxColorValue = max(x[[1]])
+			maxColorValue = max(maxColorValue, max(x[[1]]))
 		}
 	}
 
 	if(is.character(stretch)) {
 		if(!stretch %in% c("percent", "histogram")){
 			stretch.method = "percent"
-			message("Stretch not in c('histogram', 'percent'), then 'percent' applied")
 		} else {
 			stretch.method = stretch
 		}

--- a/R/plot.R
+++ b/R/plot.R
@@ -435,12 +435,13 @@ contour.stars = function(x, ...) {
 #' @param dimension dimension name or number to reduce
 #' @param use_alpha logical; if TRUE, the fourth band will be used as alpha values
 #' @param maxColorValue integer; maximum value for colors
-#' @param stretch logical or character; if \code{TRUE}, each band is stretched to 0 ... \code{maxColorValue}
-#' by "percent clip"; if character \code{"percent"} is required \code{probs}; if
-#' character \code{"histogram"} a "histogram equalization" is performed. Other character
-#' values are ignored, insted method used is "percent".
-#' @param probs probability values for quantiles used for stretching. Ignored when \code{stretch}
-#' is one of \code{NULL}, \code{FALSE}, or character \code{"histogram"}
+#' @param stretch logical or character; if \code{TRUE} or \code{"percent"},
+#' each band is stretched to 0 ... maxColorValue by "percent clip" method using
+#' probs values. If \code{"histogram"} a "histogram equalization" is performed,
+#' prob values are ignored. If stretch is \code{NULL} or \code{FALSE}, no stretching
+#' is performed. Other character values are interpreted as "percent" and a message
+#' will be printed.
+#' @param probs probability values for quantiles used for stretching by "percent".
 #' @seealso \link{st_apply}, \link[grDevices]{rgb}
 #' @details the dimension's bands are mapped to red, green, blue, alpha; if a different
 #' ordering is wanted, use \link{[.stars} to reorder a dimension, see examples

--- a/R/plot.R
+++ b/R/plot.R
@@ -437,8 +437,8 @@ contour.stars = function(x, ...) {
 #' @param maxColorValue integer; maximum value for colors
 #' @param stretch logical or character; if \code{TRUE} or \code{"percent"},
 #' each band is stretched to 0 ... maxColorValue by "percent clip" method using
-#' probs values. If \code{"histogram"}, a "histogram equalization" is performed,
-#' prob values are ignored. If stretch is \code{NULL} or \code{FALSE}, no stretching
+#' probs values. If \code{"histogram"}, a "histogram equalization" is performed
+#' (\code{probs} values are ignored). If stretch is \code{NULL} or \code{FALSE}, no stretching
 #' is performed. Other character values are interpreted as "percent" and a message
 #' will be printed.
 #' @param probs probability values for quantiles used for stretching by "percent".

--- a/R/plot.R
+++ b/R/plot.R
@@ -7,7 +7,7 @@ make_label = function(x, i = 1) {
 }
 
 #' plot stars object, with subplots for each level of first non-spatial dimension
-#' 
+#'
 #' plot stars object, with subplots for each level of first non-spatial dimension, and customization of legend key
 #'
 #' @name plot
@@ -29,12 +29,12 @@ make_label = function(x, i = 1) {
 #' @param center_time logical; if \code{TRUE}, sub-plot titles will show the center of time intervals, otherwise their start
 #' @param hook NULL or function; hook function that will be called on every sub-plot.
 #' @param mfrow length-2 integer vector with nrows, ncolumns of a composite plot, to override the default layout
-#' @details 
+#' @details
 #' Downsampling: a value for \code{downsample} of 0 or 1 causes no downsampling, 2 that every second dimension value is sampled, 3 that every third dimension value is sampled, and so on; can be specified for each dimension.
 #' @export
-plot.stars = function(x, y, ..., join_zlim = TRUE, main = make_label(x, 1), axes = FALSE, 
+plot.stars = function(x, y, ..., join_zlim = TRUE, main = make_label(x, 1), axes = FALSE,
 		downsample = TRUE, nbreaks = 11, breaks = "quantile", col = grey(1:(nbreaks-1)/nbreaks),
-		key.pos = get_key_pos(x, ...), key.width = lcm(1.8), key.length = 0.618, 
+		key.pos = get_key_pos(x, ...), key.width = lcm(1.8), key.length = 0.618,
 		reset = TRUE, box_col = grey(.8), center_time = FALSE, hook = NULL, mfrow = NULL) {
 
 	flatten = function(x, i) { # collapse all non-x/y dims into one, and select "layer" i
@@ -114,8 +114,8 @@ plot.stars = function(x, y, ..., join_zlim = TRUE, main = make_label(x, 1), axes
 					.image_scale_factor(levels(values), col, key.pos = key.pos,
 						key.width = key.width, key.length = key.length, axes = axes, ...)
 				else
-					.image_scale(values, col, breaks = breaks, key.pos = key.pos, 
-						key.width = key.width, key.length = key.length, axes = axes, ...) 
+					.image_scale(values, col, breaks = breaks, key.pos = key.pos,
+						key.width = key.width, key.length = key.length, axes = axes, ...)
 			}
 
 			# map panel:
@@ -125,7 +125,7 @@ plot.stars = function(x, y, ..., join_zlim = TRUE, main = make_label(x, 1), axes
 			par(mar = mar)
 
 			# plot the map:
-			image(x, ..., axes = axes, breaks = breaks, col = col, key.pos = key.pos, 
+			image(x, ..., axes = axes, breaks = breaks, col = col, key.pos = key.pos,
 				key.width = key.width, key.length = key.length, main = NULL)
 			if (!is.null(main))
 				title(main)
@@ -136,7 +136,7 @@ plot.stars = function(x, y, ..., join_zlim = TRUE, main = make_label(x, 1), axes
 				key.pos = NULL
 			lt = sf::.get_layout(st_bbox(x), dims[3], par("din"),
 						if (join_zlim && key.pos.missing) -1 else key.pos, key.width, mfrow = mfrow)
-			title_size = if (is.null(main)) 
+			title_size = if (is.null(main))
 					0
 				else
 					1.2
@@ -171,14 +171,14 @@ plot.stars = function(x, y, ..., join_zlim = TRUE, main = make_label(x, 1), axes
 					.image_scale_factor(levels(values), col, key.pos = lt$key.pos,
 						key.width = key.width, key.length = key.length, axes = axes,...)
 				else
-					.image_scale(values, col, breaks = breaks, key.pos = lt$key.pos, 
+					.image_scale(values, col, breaks = breaks, key.pos = lt$key.pos,
 						key.width = key.width, key.length = key.length, axes = axes,...)
 			}
 		}
 	} else if (has_sfc(x)) {
 #		if (key.pos.missing)
 #			key.pos = -1
-		plot(st_as_sf(x), ..., breaks = breaks, key.pos = key.pos, key.length = key.length, 
+		plot(st_as_sf(x), ..., breaks = breaks, key.pos = key.pos, key.length = key.length,
 			key.width = key.width, reset = reset, axes = axes, main = main)
 	} else
 		stop("no raster, no features geometries: no default plot method set up yet!")
@@ -201,7 +201,7 @@ get_breaks = function(x, breaks, nbreaks, logz = NULL) {
 			values = as.numeric(values)
 		n.unq = length(unique(na.omit(values)))
 		if (! all(is.na(values)) && n.unq > 1)
-			classInt::classIntervals(na.omit(values), min(nbreaks-1, n.unq), breaks, 
+			classInt::classIntervals(na.omit(values), min(nbreaks-1, n.unq), breaks,
 				warnSmallN = FALSE)$brks
 		else
 			range(values, na.rm = TRUE) # lowest and highest!
@@ -235,10 +235,10 @@ get_breaks = function(x, breaks, nbreaks, logz = NULL) {
 #' x = read_stars(tif)
 #' image(x, col = grey((3:9)/10))
 #' image(x, rgb = c(1,3,5)) # rgb composite
-image.stars = function(x, ..., band = 1, attr = 1, asp = NULL, rgb = NULL, 
+image.stars = function(x, ..., band = 1, attr = 1, asp = NULL, rgb = NULL,
 		maxColorValue = ifelse(inherits(rgb, "data.frame"), 255, max(x[[attr]], na.rm = TRUE)),
 		xlab = if (!axes) "" else names(d)[1], ylab = if (!axes) "" else names(d)[2],
-		xlim = st_bbox(extent)$xlim, ylim = st_bbox(extent)$ylim, text_values = FALSE, 
+		xlim = st_bbox(extent)$xlim, ylim = st_bbox(extent)$ylim, text_values = FALSE,
 		text_color = 'black', axes = FALSE,
 		interpolate = FALSE, as_points = FALSE, key.pos = NULL, logz = FALSE,
 		key.width = lcm(1.8), key.length = 0.618, add.geom = NULL, border = NA,
@@ -307,7 +307,7 @@ image.stars = function(x, ..., band = 1, attr = 1, asp = NULL, rgb = NULL,
 	ar = aperm(ar, c(dimxn, dimyn, others))
 	if (text_values)
 		ar_text = ar # keep original order for cell text labels
-	
+
 	if (is.null(rgb) && is.character(ar))
 		rgb = TRUE
 
@@ -360,8 +360,8 @@ image.stars = function(x, ..., band = 1, attr = 1, asp = NULL, rgb = NULL,
 			else
 				plot(x, pal = col, ...) # need to swap arg names: FIXME:?
 		}
-		mplot(x, xlab = xlab, ylab = ylab, xlim = xlim, ylim = ylim, axes = axes, reset = FALSE, 
-			key.pos = key.pos, key.width = key.width, key.length = key.length, logz = logz, 
+		mplot(x, xlab = xlab, ylab = ylab, xlim = xlim, ylim = ylim, axes = axes, reset = FALSE,
+			key.pos = key.pos, key.width = key.width, key.length = key.length, logz = logz,
 			border = border, ...)
 	} else { # regular & rectilinear grid, no RGB:
 		if (y_is_neg) { # need to flip y?
@@ -370,7 +370,7 @@ image.stars = function(x, ..., band = 1, attr = 1, asp = NULL, rgb = NULL,
 				else
 					ar[ , rev(seq_len(dim(ar)[2])), band] # FIXME: breaks if more than 3?
 		}
-		image.default(dims[[ dimx ]], dims[[ dimy ]], ar, asp = asp, xlab = xlab, ylab = ylab, 
+		image.default(dims[[ dimx ]], dims[[ dimy ]], ar, asp = asp, xlab = xlab, ylab = ylab,
 			xlim = xlim, ylim = ylim, axes = FALSE, useRaster = useRaster && !is_rectilinear(x), ...)
 	}
 	if (text_values) {
@@ -394,9 +394,9 @@ image.stars = function(x, ..., band = 1, attr = 1, asp = NULL, rgb = NULL,
 	}
 }
 
-# compute the degree of downsampling allowed to still have more than 
+# compute the degree of downsampling allowed to still have more than
 # one cell per screen/device pixel:
-get_downsample = function(dims, px = dev.size("px")) { 
+get_downsample = function(dims, px = dev.size("px")) {
 	floor(sqrt(prod(dims) / prod(px)))
 }
 
@@ -429,16 +429,20 @@ contour.stars = function(x, ...) {
 }
 
 #' reduce dimension to rgb (alpha) hex values
-#' 
+#'
 #' @export
 #' @param x object of class \code{stars}
 #' @param dimension dimension name or number to reduce
 #' @param use_alpha logical; if TRUE, the fourth band will be used as alpha values
 #' @param maxColorValue integer; maximum value for colors
-#' @param stretch logical; if \code{TRUE}, each band is stretched to 0 ... \code{maxColorValue}
-#' @param probs probability values for quantiles used for stretching
+#' @param stretch logical or character; if \code{TRUE}, each band is stretched to 0 ... \code{maxColorValue}
+#' by "percent clip"; if character \code{"percent"} is required \code{probs}; if
+#' character \code{"histogram"} a "histogram equalization" is performed. Other character
+#' values are ignored, insted method used is "percent".
+#' @param probs probability values for quantiles used for stretching. Ignored when \code{stretch}
+#' is one of \code{NULL}, \code{FALSE}, or character \code{"histogram"}
 #' @seealso \link{st_apply}, \link[grDevices]{rgb}
-#' @details the dimension's bands are mapped to red, green, blue, alpha; if a different 
+#' @details the dimension's bands are mapped to red, green, blue, alpha; if a different
 #' ordering is wanted, use \link{[.stars} to reorder a dimension, see examples
 #' @examples
 #' tif = system.file("tif/L7_ETMs.tif", package = "stars")
@@ -448,46 +452,84 @@ contour.stars = function(x, ...) {
 #' if (require(ggplot2)) {
 #'  ggplot() + geom_stars(data = r) + scale_fill_identity()
 #' }
-st_rgb = function(x, dimension = 3, use_alpha = dim(x)[dimension] == 4, maxColorValue = 255L, 
-		probs = c(0., 1.), stretch = FALSE) {
+st_rgb <- function (x,
+					dimension = 3,
+					use_alpha = dim(x)[dimension] == 4,
+					maxColorValue = 255L,
+					probs = c(0, 1),
+					stretch = NULL) {
 	if (is.character(dimension))
 		dimension = match(dimension, names(dim(x)))
-	stopifnot(is.numeric(dimension), length(dimension)==1)
-	if (!dim(x)[dimension] %in% c(3,4))
-		stop(paste("number of bands along dimension", dimension, "should be 3 or 4"))
+	stopifnot(is.numeric(dimension), length(dimension) == 1)
+	if (!dim(x)[dimension] %in% c(3, 4))
+		stop(paste("number of bands along dimension", dimension,
+				   "should be 3 or 4"))
 	dims = setdiff(seq_along(dim(x)), dimension)
-	cutoff = function(x, probs) {
-		qs = if (all(probs == c(0., 1.)))
+	cutoff = function(x, probs, stretch.method = "percent") {
+		if(stretch.method == "percent"){
+			qs = if (all(probs == c(0, 1)))
 				range(x)
-			else
-				quantile(x, probs, na.rm = TRUE)
-		x = (x - qs[1])/(qs[2] - qs[1])
-		x[x > 1] = 1
-		x[x < 0] = 0
-		x * maxColorValue
+			else quantile(x, probs, na.rm = TRUE)
+			x = (x - qs[1])/(qs[2] - qs[1])
+			x[x > 1] = 1
+			x[x < 0] = 0
+			x * maxColorValue
+		} else if(stretch.method == "histogram"){
+			x = stats::ecdf(x)(x)
+			x * maxColorValue
+		} else {
+			x
+		}
 	}
-	if (stretch)
-		x = st_apply(x, dimension, cutoff, probs = probs)
+
+	if(is.null(stretch)) {
+		stretch.method = "none"
+		stretch = FALSE
+	}
+
+	if(is.logical(stretch)) {
+		if(stretch){
+			stretch.method = "percent"
+			message("Stretch as logical == TRUE, then percent clip by probs is applied")
+		} else {
+			maxColorValue = max(x[[1]])
+		}
+	}
+
+	if(is.character(stretch)) {
+		if(!stretch %in% c("percent", "histogram")){
+			stretch.method = "percent"
+			message("Stretch not in c('histogram', 'percent'), then 'percent' applied")
+		} else {
+			stretch.method = stretch
+		}
+		stretch = TRUE
+	}
+
+	if(stretch)
+		x = st_apply(x, dimension, cutoff, probs = probs, stretch.method = stretch.method)
+
 	if (anyNA(x[[1]])) {
 		rgb4 = function(r, g, b, a) {
-			r = cbind(as.vector(r), as.vector(g), as.vector(b), as.vector(a))
+			r = cbind(as.vector(r), as.vector(g), as.vector(b),
+					  as.vector(a))
 			sel = !apply(r, 1, anyNA)
 			ret = rep(NA_character_, nrow(r))
-			ret[sel] = rgb(r[sel,1:3], alpha = a[sel], maxColorValue = maxColorValue) 
+			ret[sel] = rgb(r[sel, 1:3], alpha = a[sel], maxColorValue = maxColorValue)
 			structure(ret, dim = dim(g))
 		}
 		rgb3 = function(r, g, b) {
 			r = cbind(as.vector(r), as.vector(g), as.vector(b))
 			sel = !apply(r, 1, anyNA)
 			ret = rep(NA_character_, nrow(r))
-			ret[sel] = rgb(r[sel,1:3], maxColorValue = maxColorValue) 
+			ret[sel] = rgb(r[sel, 1:3], maxColorValue = maxColorValue)
 			structure(ret, dim = dim(g))
 		}
 	} else {
-		rgb4 = function(r, g, b, a) 
-			structure(rgb(r, g, b, a, maxColorValue = maxColorValue), dim = dim(r))
-		rgb3 = function(r, g, b)
-			structure(rgb(r, g, b,    maxColorValue = maxColorValue), dim = dim(r))
+		rgb4 = function(r, g, b, a) structure(rgb(r, g, b, a,
+												  maxColorValue = maxColorValue), dim = dim(r))
+		rgb3 = function(r, g, b) structure(rgb(r, g, b, maxColorValue = maxColorValue),
+										   dim = dim(r))
 	}
 	st_apply(x, dims, if (use_alpha) rgb4 else rgb3)
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -452,6 +452,14 @@ contour.stars = function(x, ...) {
 #' if (require(ggplot2)) {
 #'  ggplot() + geom_stars(data = r) + scale_fill_identity()
 #' }
+#' r = st_rgb(x[,,,3:1],
+#' 		   probs = c(0.01, 0.99),
+#' 		   stretch = "percent")
+#' plot(r)
+#' r = st_rgb(x[,,,3:1],
+#' 		   probs = c(0.01, 0.99),
+#' 		   stretch = "histogram")
+#' plot(r)
 st_rgb <- function (x,
 					dimension = 3,
 					use_alpha = dim(x)[dimension] == 4,

--- a/man/st_rgb.Rd
+++ b/man/st_rgb.Rd
@@ -26,8 +26,8 @@ st_rgb(
 
 \item{stretch}{logical or character; if \code{TRUE} or \code{"percent"},
 each band is stretched to 0 ... maxColorValue by "percent clip" method using
-probs values. If \code{"histogram"}, a "histogram equalization" is performed,
-prob values are ignored. If stretch is \code{NULL} or \code{FALSE}, no stretching
+probs values. If \code{"histogram"}, a "histogram equalization" is performed
+(\code{probs} values are ignored). If stretch is \code{NULL} or \code{FALSE}, no stretching
 is performed. Other character values are interpreted as "percent" and a message
 will be printed.}
 }

--- a/man/st_rgb.Rd
+++ b/man/st_rgb.Rd
@@ -10,7 +10,7 @@ st_rgb(
   use_alpha = dim(x)[dimension] == 4,
   maxColorValue = 255L,
   probs = c(0, 1),
-  stretch = FALSE
+  stretch = NULL
 )
 }
 \arguments{
@@ -22,15 +22,20 @@ st_rgb(
 
 \item{maxColorValue}{integer; maximum value for colors}
 
-\item{probs}{probability values for quantiles used for stretching}
+\item{probs}{probability values for quantiles used for stretching by "percent".}
 
-\item{stretch}{logical; if \code{TRUE}, each band is stretched to 0 ... \code{maxColorValue}}
+\item{stretch}{logical or character; if \code{TRUE} or \code{"percent"},
+each band is stretched to 0 ... maxColorValue by "percent clip" method using
+probs values. If \code{"histogram"} a "histogram equalization" is performed,
+prob values are ignored. If stretch is \code{NULL} or \code{FALSE}, no stretching
+is performed. Other character values are interpreted as "percent" and a message
+will be printed.}
 }
 \description{
 reduce dimension to rgb (alpha) hex values
 }
 \details{
-the dimension's bands are mapped to red, green, blue, alpha; if a different 
+the dimension's bands are mapped to red, green, blue, alpha; if a different
 ordering is wanted, use \link{[.stars} to reorder a dimension, see examples
 }
 \examples{
@@ -41,6 +46,14 @@ r = st_rgb(x[,,,c(6,5,4,3)], 3, use_alpha=TRUE) # now R=6,G=5,B=4,alpha=3
 if (require(ggplot2)) {
  ggplot() + geom_stars(data = r) + scale_fill_identity()
 }
+r = st_rgb(x[,,,3:1],
+		   probs = c(0.01, 0.99),
+		   stretch = "percent")
+plot(r)
+r = st_rgb(x[,,,3:1],
+		   probs = c(0.01, 0.99),
+		   stretch = "histogram")
+plot(r)
 }
 \seealso{
 \link{st_apply}, \link[grDevices]{rgb}

--- a/man/st_rgb.Rd
+++ b/man/st_rgb.Rd
@@ -24,21 +24,12 @@ st_rgb(
 
 \item{probs}{probability values for quantiles used for stretching by "percent".}
 
-<<<<<<< HEAD
 \item{stretch}{logical or character; if \code{TRUE} or \code{"percent"},
 each band is stretched to 0 ... maxColorValue by "percent clip" method using
-probs values. If \code{"histogram"} a "histogram equalization" is performed,
+probs values. If \code{"histogram"}, a "histogram equalization" is performed,
 prob values are ignored. If stretch is \code{NULL} or \code{FALSE}, no stretching
 is performed. Other character values are interpreted as "percent" and a message
 will be printed.}
-=======
-\item{stretch}{logical or character; if \code{TRUE} or "percent" (character),
-each band is stretched to 0 ... maxColorValue by "percent clip" method using
-probs values. If \code{"histogram"} a "histogram equalization" is performed,
-prob values are ignored. If stretch is NULL or FALSE, no stretching is performed.
-Other character values are interpreted as "percent" and a message will printed on
-console.}
->>>>>>> 337e0b3b2b4d99da2ecfa5e4eed3d8c2cf20cd33
 }
 \description{
 reduce dimension to rgb (alpha) hex values


### PR DESCRIPTION
Please see some changes in `st_rgb()` function, acoording to [tmap: 345](https://github.com/mtennekes/tmap/issues/345) discussion. Local tested details:

``` r
library(stars)
#> Loading required package: abind
#> Loading required package: sf
#> Linking to GEOS 3.8.0, GDAL 3.0.4, PROJ 6.3.1
library(tmap)

# Example data ---
tf = tempfile()
td = tempdir()

download.file("https://github.com/mtennekes/tmap/files/5987567/rgbexample.tif.zip",
              destfile = tf)

unzip(tf, exdir = td)

file_path = file.path(td, "rgbexample.tif")

x = read_stars(file_path)

# No stretch
st_rgb(x[,,,4:2],
       dimension = 3,
       maxColorValue = 255L,
       use_alpha = FALSE,
       probs = c(0.02, 0.98), #drop heads and tails
       stretch = NULL) |> # NULL by default. Is converted to stretch = FALSE
  tm_shape() +
  tm_raster()
```

![](https://i.imgur.com/IViJkwa.png)

``` r
# stretching by "Percent clip" chosing autmatically
st_rgb(x[,,,4:2],
       dimension = 3,
       maxColorValue = 255L,
       use_alpha = FALSE,
       probs = c(0.02, 0.98), #drop heads and tails
       stretch = TRUE) |>
  tm_shape() +
  tm_raster()
#> Stretch as logical == TRUE, then percent clip by probs is applied
```

![](https://i.imgur.com/p6rWZaI.png)

``` r
# stretching by "Percent clip" user defined
st_rgb(x[,,,4:2],
       dimension = 3,
       maxColorValue = 255L,
       use_alpha = FALSE,
       probs = c(0.03, 0.97), #drop heads and tails
       stretch = "percent") |>
  tm_shape() +
  tm_raster()
```

![](https://i.imgur.com/MQgRaT4.png)

``` r
# stretching by "histogram equalizer"
st_rgb(x[,,,4:2],
       dimension = 3,
       maxColorValue = 255L,
       use_alpha = FALSE,
       probs = c(0.02, 0.98), #ignored by stretch method
       stretch = "histogram") |>
  tm_shape() +
  tm_raster()
```

![](https://i.imgur.com/dKR3LTF.png)

<sup>Created on 2021-06-11 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 4.1.0 (2021-05-18)
#>  os       Ubuntu 20.04.2 LTS          
#>  system   x86_64, linux-gnu           
#>  ui       X11                         
#>  language (EN)                        
#>  collate  en_US.UTF-8                 
#>  ctype    en_US.UTF-8                 
#>  tz       America/Guayaquil           
#>  date     2021-06-11                  
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package      * version  date       lib source        
#>  abind        * 1.4-5    2016-07-21 [2] CRAN (R 4.0.2)
#>  assertthat     0.2.1    2019-03-21 [2] CRAN (R 4.0.2)
#>  backports      1.2.1    2020-12-09 [2] CRAN (R 4.0.3)
#>  base64enc      0.1-3    2015-07-28 [2] CRAN (R 4.0.2)
#>  class          7.3-19   2021-05-03 [4] CRAN (R 4.0.5)
#>  classInt       0.4-3    2020-04-07 [2] CRAN (R 4.0.2)
#>  cli            2.5.0    2021-04-26 [2] CRAN (R 4.0.5)
#>  codetools      0.2-18   2020-11-04 [4] CRAN (R 4.0.3)
#>  crayon         1.4.1    2021-02-08 [2] CRAN (R 4.0.4)
#>  crosstalk      1.1.1    2021-01-12 [2] CRAN (R 4.0.3)
#>  curl           4.3.1    2021-04-30 [2] CRAN (R 4.0.5)
#>  DBI            1.1.1    2021-01-15 [2] CRAN (R 4.0.3)
#>  dichromat      2.0-0    2013-01-24 [2] CRAN (R 4.0.2)
#>  digest         0.6.27   2020-10-24 [2] CRAN (R 4.0.3)
#>  dplyr          1.0.6    2021-05-05 [2] CRAN (R 4.0.5)
#>  e1071          1.7-7    2021-05-23 [2] CRAN (R 4.1.0)
#>  ellipsis       0.3.2    2021-04-29 [2] CRAN (R 4.0.5)
#>  evaluate       0.14     2019-05-28 [2] CRAN (R 4.0.2)
#>  fansi          0.5.0    2021-05-25 [2] CRAN (R 4.1.0)
#>  fs             1.5.0    2020-07-31 [2] CRAN (R 4.0.2)
#>  generics       0.1.0    2020-10-31 [2] CRAN (R 4.0.3)
#>  glue           1.4.2    2020-08-27 [2] CRAN (R 4.0.2)
#>  highr          0.9      2021-04-16 [2] CRAN (R 4.0.5)
#>  htmltools      0.5.1.1  2021-01-22 [2] CRAN (R 4.0.3)
#>  htmlwidgets    1.5.3    2020-12-10 [2] CRAN (R 4.0.3)
#>  httr           1.4.2    2020-07-20 [2] CRAN (R 4.0.2)
#>  KernSmooth     2.23-20  2021-05-03 [4] CRAN (R 4.0.5)
#>  knitr          1.33     2021-04-24 [2] CRAN (R 4.0.5)
#>  lattice        0.20-44  2021-05-02 [4] CRAN (R 4.1.0)
#>  leafem         0.1.6    2021-05-24 [2] CRAN (R 4.1.0)
#>  leaflet        2.0.4.1  2021-01-07 [2] CRAN (R 4.0.3)
#>  leafsync       0.1.0    2019-03-05 [2] CRAN (R 4.0.2)
#>  lifecycle      1.0.0    2021-02-15 [2] CRAN (R 4.0.4)
#>  lwgeom         0.2-6    2021-04-02 [2] CRAN (R 4.0.5)
#>  magrittr       2.0.1    2020-11-17 [2] CRAN (R 4.0.3)
#>  mime           0.10     2021-02-13 [2] CRAN (R 4.0.4)
#>  pillar         1.6.1    2021-05-16 [2] CRAN (R 4.0.5)
#>  pkgconfig      2.0.3    2019-09-22 [2] CRAN (R 4.0.2)
#>  png            0.1-7    2013-12-03 [2] CRAN (R 4.0.2)
#>  proxy          0.4-25   2021-03-05 [2] CRAN (R 4.0.5)
#>  purrr          0.3.4    2020-04-17 [2] CRAN (R 4.0.2)
#>  R6             2.5.0    2020-10-28 [2] CRAN (R 4.0.3)
#>  raster         3.4-10   2021-05-03 [2] CRAN (R 4.0.5)
#>  RColorBrewer   1.1-2    2014-12-07 [2] CRAN (R 4.0.2)
#>  Rcpp           1.0.6    2021-01-15 [2] CRAN (R 4.0.3)
#>  reprex         2.0.0    2021-04-02 [2] CRAN (R 4.0.5)
#>  rlang          0.4.11   2021-04-30 [2] CRAN (R 4.0.5)
#>  rmarkdown      2.8      2021-05-07 [2] CRAN (R 4.0.5)
#>  sessioninfo    1.1.1    2018-11-05 [2] CRAN (R 4.0.5)
#>  sf           * 0.9-8    2021-03-17 [2] CRAN (R 4.0.5)
#>  sp             1.4-5    2021-01-10 [2] CRAN (R 4.0.3)
#>  stars        * 0.5-2    2021-03-17 [2] CRAN (R 4.0.5) # gavg712/stars version
#>  stringi        1.6.2    2021-05-17 [2] CRAN (R 4.0.5)
#>  stringr        1.4.0    2019-02-10 [2] CRAN (R 4.0.2)
#>  styler         1.4.1    2021-03-30 [2] CRAN (R 4.0.5)
#>  tibble         3.1.2    2021-05-16 [2] CRAN (R 4.0.5)
#>  tidyselect     1.1.1    2021-04-30 [2] CRAN (R 4.0.5)
#>  tmap         * 3.3-1    2021-03-15 [2] CRAN (R 4.0.5)
#>  tmaptools      3.1-1    2021-01-19 [2] CRAN (R 4.0.3)
#>  units          0.7-1    2021-03-16 [2] CRAN (R 4.0.5)
#>  utf8           1.2.1    2021-03-12 [2] CRAN (R 4.0.5)
#>  vctrs          0.3.8    2021-04-29 [2] CRAN (R 4.0.5)
#>  viridisLite    0.4.0    2021-04-13 [2] CRAN (R 4.0.5)
#>  withr          2.4.2    2021-04-18 [2] CRAN (R 4.0.5)
#>  xfun           0.23     2021-05-15 [2] CRAN (R 4.0.5)
#>  XML            3.99-0.6 2021-03-16 [2] CRAN (R 4.0.5)
#>  xml2           1.3.2    2020-04-23 [2] CRAN (R 4.0.2)
#>  yaml           2.2.1    2020-02-01 [2] CRAN (R 4.0.2)
#> 
#> [1] /home/gavg712/R/x86_64-pc-linux-gnu-library/4.1
#> [2] /usr/local/lib/R/site-library
#> [3] /usr/lib/R/site-library
#> [4] /usr/lib/R/library
```

</details>
