### PR TITLE
more efficient slice.stars_proxy

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -154,8 +154,57 @@ slice.stars <- function(.data, along, index, ..., drop = length(index) == 1) {
 }
 
 #' @name dplyr
-slice.stars_proxy = function(.data, ...) {
-	collect(.data, match.call(), "slice", ".data", env = parent.frame())
+slice.stars_proxy <- function(.data, along, index, ...) {
+  # TODO: add adrop argument, this requires an eager implementation of
+  # adrop.stars_proxy
+
+  # If there are already operations queued, just add to the queue
+  if (!is.null(attr(.data, "call_list")))
+    return(collect(.data, match.call(), "slice", ".data",
+                   env = parent.frame(), ...))
+
+  # figure out which dimensions are part of the files
+  vecsize <- rev(cumprod(rev(dim(.data))))
+
+  # NOTE: The first set of dimensions corresponds to the dimensions in the
+  # files. The second set of dimensions corresponds to the list of files. It may
+  # be undecided where exactly the break is (at least without reading in the
+  # files) if there are a singleton dimensions, I am not sure if this matters,
+  # for now just assume the maximum index.
+
+  # Can we assume, that all elements of .data are the same?
+  first_concat_dim <- max(which(vecsize == length(.data[[1]])))
+  stopifnot(first_concat_dim > 0)
+  all_dims <- stars::st_dimensions(.data)
+  file_dims <- all_dims[seq_len(first_concat_dim - 1)]
+  concat_dims <- all_dims[first_concat_dim:length(dim(.data))]
+  d_concat_dims <- dim(concat_dims)
+  l_concat_vec <- prod(d_concat_dims)
+
+  # what is the dimension we have to subset
+  ix <- which(names(all_dims) == along) - length(file_dims)
+  stopifnot(length(ix) == 1)
+
+  # if the slice is on file dimensions we have to queue the operation
+  if (ix <= 0)
+    return(collect(.data, match.call(), "slice", ".data",
+                   env = parent.frame(), ...))
+
+  # subset indices for the files, it may be faster to calculate these and not
+  # take them from an array.
+  d <- array(seq_len(l_concat_vec), d_concat_dims)
+  idx <- rep(list(quote(expr = )), length(d_concat_dims))
+  idx[[ix]] <- index
+  vidx <- as.vector(do.call(`[`, c(list(d), idx)))
+
+  # The actual subsetting of files and dimensions
+  file_list_new <- lapply(.data, function(x) x[vidx])
+  all_dims[[along]] <- all_dims[[along]][index]
+
+  # construct stars_proxy
+  stars:::st_stars_proxy(as.list(file_list_new), all_dims,
+                         NA_value = attr(.data, "NA_value"),
+                         resolutions = attr(.data, "resolutions"))
 }
 
 #' @name st_coordinates

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -1,0 +1,37 @@
+
+test_that("slice", {
+
+  f <- system.file("nc/reduced.nc", package = "stars")
+  nc <- read_ncdf(f, proxy = TRUE)
+  expect_s3_class(nc, "stars_proxy")
+
+  # Slicing after other lazy operations should be lazy
+  nc2 <- adrop(nc)
+  nc3 <- slice(nc2, "lon", 90)
+  expect_equal(length(attr(nc3, "call_list")), 2)
+
+  # Slicing dimension that are part of the file should be lazy
+  nc4 <- slice(nc, "lon", 90)
+  expect_equal(length(attr(nc4, "call_list")), 1)
+
+  # Trailing singleton dimensions in files
+  nc5 <- slice(nc, "time", 1)
+  expect_null(attr(nc5, "call_list"))
+  expect_equal(st_dimensions(nc), st_dimensions(nc5))
+
+  nc6 <- c(nc, nc, nc, nc, along = "dummy")
+  expect_equal(dim(nc6)["dummy"], c(dummy = 4))
+  expect_s3_class(nc6, "stars_proxy")
+
+  nc7 <- slice(nc6, "dummy", 1)
+  expect_s3_class(nc7, "stars_proxy")
+  expect_equal(dim(nc7)["dummy"], c(dummy = 1))
+  expect_null(attr(nc7, "call_list"))
+  expect_equal(names(nc7), names(nc6))
+
+  nc8 <- slice(nc6, "dummy", 2:3)
+  expect_s3_class(nc8, "stars_proxy")
+  expect_equal(dim(nc8)["dummy"], c(dummy = 2))
+  expect_null(attr(nc8, "call_list"))
+  expect_equal(names(nc8), names(nc6))
+})


### PR DESCRIPTION
This is an implementation for an efficient `slice.stars_proxy`. I am not familiar with the code base so please check the code.

- Can I assume that all elements of a `stars_proxy` object are the same or at least have the same length?
- Is there a canonical way to find out which dimensions of a `stars_proxy` object are part of the files and which ones are are for the list of files.
   - What to do with singleton dimension that can make this border not well defined from looking at `st_dimensions(.data)` only.
- I have written some unit test not sure how well these cover all special cases, is there a dataset that is split up across files that I can use for unit testing? 

#527