### PR TITLE
remove NAs in detecting min factor level

### DIFF
--- a/R/raster.R
+++ b/R/raster.R
@@ -185,7 +185,7 @@ st_as_stars.SpatRaster = function(.x, ..., ignore_file = FALSE) {
 				colors = NULL
 			else if (length(colors) == length(levels) + 1) # remove last color?
 				colors = colors[-length(colors)]
-			if (min(v) == 0) # +warn here?
+			if (min(v, na.rm=TRUE) == 0) # +warn here?
 				v = v + 1
 			v = structure(v, class = "factor", levels = as.character(l), colors = colors)
 		}


### PR DESCRIPTION
Conversion from categorical SpatRaster was failing if NAs were present. I would get "Error in if (min(v) == 0) v = v + 1 : missing value where TRUE/FALSE needed" because it would evaluate to NA instead of TRUE or FALSE