### PR TITLE
make st_as_sf.stars() work with “malformed” factors

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -137,8 +137,15 @@ st_as_sf.stars = function(x, ..., as_points = FALSE, merge = FALSE, na.rm = TRUE
 				geotransform = get_geotransform(x), use_contours = FALSE, connect8 = connect8, ...)
 
 		# factor levels?
-		if (!is.null(lev <- attr(x[[1]], "levels")))
-			ret[[1]] = structure(ret[[1]], class = "factor", levels = lev)
+		if (!is.null(lev <- attr(x[[1]], "levels"))) {
+			ex = attr(x[[1]], "exclude")
+			if(any(ex)){
+				id = (seq_along(ex) - 1)[!ex] # index-values matching to levels
+				ret[[1]] = structure(match(ret[[1]], id), class = "factor", levels = lev)
+			} else {
+				ret[[1]] = structure(ret[[1]], class = "factor", levels = lev)
+			}
+		}
 		st_set_crs(ret, crs)
 	} else {
 		if (merge)


### PR DESCRIPTION
Currently, if its argument `merge` is set to `TRUE`, `stars:::st_as_sf.stars()`
cannot handle factor-input with levels matched to index-values NOT ranging either
from 0 to n - 1 or from 1 to n, where n is the number of levels / categories.
Here is an example to illustrate the point:

``` r
library(terra)
#> terra 1.6.4
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.3.2, PROJ 8.1.1; sf_use_s2() is TRUE
packageVersion("sf")
#> [1] '1.0.9'
library(stars) # development version 2022-08-12 (main branch)
#> Loading required package: abind
packageVersion("stars")
#> [1] '0.5.7'
```

create `stars` object:

``` r
set.seed(1)
r <- rast(nrows = 5, ncols = 10, xmin = 0, xmax = 10, ymin = 0, ymax = 5)
values(r) <- sample(4, ncell(r), replace = TRUE)
r <- (r - 1)*2
levels(r)<- data.frame(id = (0:3)*2, cat = LETTERS[1:4])
s <- st_as_stars(r)
# s[[1]]
```

plot the `stars` object:

``` r
plot(s)
```

![](https://i.imgur.com/Sj0r9NY.png)

try to convert `stars` object into an `sf` object:

``` r
st_as_sf(s, merge = TRUE)
#> Simple feature collection with 23 features and 1 field
#> Geometry type: POLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 0 ymin: 0 xmax: 10 ymax: 5
#> Geodetic CRS:  WGS 84
#> First 10 features:
#> Error in as.character.factor(x): malformed factor
plot(st_as_sf(s, merge = TRUE))
```

![](https://i.imgur.com/iC4zRmC.png)

Which doesn’t really work. `stars:::st_as_sf.stars()` throws an “error-message”
saying something about “malformed factor”, while still returning a corrupted output.

I have modified `stars:::st_as_sf.stars()` so that it can handle such “malformed”
factors. For me this has worked so far. What you do think?

<sup>Created on 2022-08-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>