### PR TITLE
Add any() since key.pos might have length > 1

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -16,13 +16,13 @@ make_label = function(x, i = 1) {
 #}
 # copy from sf:
 kw_dflt = function(x, key.pos) {
-	if (is.null(key.pos) || key.pos == 0) # no key:
+	if (is.null(key.pos) || any(key.pos == 0)) # no key:
 		return(lcm(0))
 
 	font_scale = par("ps") / 12
-	if (key.pos == -1)
+	if (any(key.pos == -1))
 		lcm(1.8 * font_scale)
-	else if (key.pos %in% c(2, 4) && (is.character(x[[1]]) || is.factor(x[[1]]))) {
+	else if (any(key.pos %in% c(2, 4)) && (is.character(x[[1]]) || is.factor(x[[1]]))) {
 		strings = if (is.factor(x[[1]]))
 				levels(x[[1]])
 			else


### PR DESCRIPTION
Hi @edzer! I created this PR to propose a fix for the following error in `stars`

``` r
library(stars)
#> Loading required package: abind
#> Loading required package: sf
#> Linking to GEOS 3.11.2, GDAL 3.7.2, PROJ 9.3.0; sf_use_s2() is TRUE
tif = system.file("tif/L7_ETMs.tif", package = "stars")
x = read_stars(tif)[, , , 1]
plot(x, key.pos = c(4, 0.1))
#> Error in is.null(key.pos) || key.pos == 0: 'length = 2' in coercion to 'logical(1)'
```

<sup>Created on 2024-02-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.3.1 (2023-06-16 ucrt)
#>  os       Windows 11 x64 (build 22631)
#>  system   x86_64, mingw32
#>  ui       RTerm
#>  language (EN)
#>  collate  English_United Kingdom.utf8
#>  ctype    English_United Kingdom.utf8
#>  tz       Europe/Rome
#>  date     2024-02-14
#>  pandoc   3.1.1 @ C:/Program Files/RStudio/resources/app/bin/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date (UTC) lib source
#>  abind       * 1.4-5   2016-07-21 [1] CRAN (R 4.3.1)
#>  class         7.3-22  2023-05-03 [2] CRAN (R 4.3.1)
#>  classInt      0.4-10  2023-09-05 [1] CRAN (R 4.3.1)
#>  cli           3.6.1   2023-03-23 [1] CRAN (R 4.3.1)
#>  DBI           1.2.1   2024-01-12 [1] CRAN (R 4.3.1)
#>  digest        0.6.33  2023-07-07 [1] CRAN (R 4.3.1)
#>  dplyr         1.1.4   2023-11-17 [1] CRAN (R 4.3.1)
#>  e1071         1.7-14  2023-12-06 [1] CRAN (R 4.3.2)
#>  evaluate      0.22    2023-09-29 [1] CRAN (R 4.3.1)
#>  fansi         1.0.6   2023-12-08 [1] CRAN (R 4.3.2)
#>  fastmap       1.1.1   2023-02-24 [1] CRAN (R 4.3.1)
#>  fs            1.6.3   2023-07-20 [1] CRAN (R 4.3.1)
#>  generics      0.1.3   2022-07-05 [1] CRAN (R 4.3.1)
#>  glue          1.7.0   2024-01-09 [1] CRAN (R 4.3.2)
#>  htmltools     0.5.6.1 2023-10-06 [1] CRAN (R 4.3.1)
#>  KernSmooth    2.23-21 2023-05-03 [2] CRAN (R 4.3.1)
#>  knitr         1.45    2023-10-30 [1] CRAN (R 4.3.2)
#>  lifecycle     1.0.4   2023-11-07 [1] CRAN (R 4.3.2)
#>  magrittr      2.0.3   2022-03-30 [1] CRAN (R 4.3.1)
#>  pillar        1.9.0   2023-03-22 [1] CRAN (R 4.3.1)
#>  pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 4.3.1)
#>  proxy         0.4-27  2022-06-09 [1] CRAN (R 4.3.1)
#>  purrr         1.0.2   2023-08-10 [1] CRAN (R 4.3.1)
#>  R.cache       0.16.0  2022-07-21 [1] CRAN (R 4.3.1)
#>  R.methodsS3   1.8.2   2022-06-13 [1] CRAN (R 4.3.1)
#>  R.oo          1.25.0  2022-06-12 [1] CRAN (R 4.3.1)
#>  R.utils       2.12.2  2022-11-11 [1] CRAN (R 4.3.1)
#>  R6            2.5.1   2021-08-19 [1] CRAN (R 4.3.1)
#>  Rcpp          1.0.12  2024-01-09 [1] CRAN (R 4.3.2)
#>  reprex        2.0.2   2022-08-17 [1] CRAN (R 4.3.1)
#>  rlang         1.1.3   2024-01-10 [1] CRAN (R 4.3.2)
#>  rmarkdown     2.25    2023-09-18 [1] CRAN (R 4.3.1)
#>  rstudioapi    0.15.0  2023-07-07 [1] CRAN (R 4.3.1)
#>  sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.3.1)
#>  sf          * 1.0-16  2024-02-05 [1] Github (r-spatial/sf@9073a52)
#>  stars       * 0.6-5   2024-02-06 [1] Github (r-spatial/stars@513f992)
#>  styler        1.10.2  2023-08-29 [1] CRAN (R 4.3.1)
#>  tibble        3.2.1   2023-03-20 [1] CRAN (R 4.3.1)
#>  tidyselect    1.2.0   2022-10-10 [1] CRAN (R 4.3.1)
#>  units         0.8-5   2023-11-28 [1] CRAN (R 4.3.2)
#>  utf8          1.2.4   2023-10-22 [1] CRAN (R 4.3.1)
#>  vctrs         0.6.5   2023-12-01 [1] CRAN (R 4.3.2)
#>  withr         2.5.1   2023-09-26 [1] CRAN (R 4.3.1)
#>  xfun          0.40    2023-08-09 [1] CRAN (R 4.3.1)
#>  yaml          2.3.7   2023-01-23 [1] CRAN (R 4.3.1)
#> 
#>  [1] C:/Users/user/AppData/Local/R/win-library/4.3
#>  [2] C:/Program Files/R/R-4.3.1/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

According to the docs: 

> numeric; side to plot a color key: 1 bottom, 2 left, 3 top, 4 right; set to NULL to omit key. Ignored if multiple columns are plotted in a single function call. Default depends on plot size, map aspect, and, if set, parameter asp. **If it has lenght 2, the second value, ranging from 0 to 1, determines where the key is placed in the available space (default: 0.5, center)**

After some simple debugging, I noticed that the error occurs in `stars:::kw_dflt`: 

https://github.com/r-spatial/stars/blob/513f992b0a6bb911a86c1f6d8fc4eb8f106597e7/R/plot.R#L17-L20

and I created this PR to propose the fix included in that commit. After that commit, we obtain the following: 

``` r
library(stars)
#> Loading required package: abind
#> Loading required package: sf
#> Linking to GEOS 3.11.2, GDAL 3.7.2, PROJ 9.3.0; sf_use_s2() is TRUE
tif = system.file("tif/L7_ETMs.tif", package = "stars")
x = read_stars(tif)[, , , 1]
plot(x, key.pos = c(4, 0.1))
```

![](https://i.imgur.com/YfJeuHL.png)<!-- -->

<sup>Created on 2024-02-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

btw: I noticed that the same error occurs in `sf` with exactly the same function. I'm not sure why the two functions are duplicated but, if you want, I can create an identical PR in the sf repo or just fix the issue there and import the function here. 