### PR TITLE
add normalize argument to st_crop

### DIFF
--- a/R/stars.R
+++ b/R/stars.R
@@ -326,7 +326,8 @@ st_cells_from_xy = function(x, xy) {
 
 #' return the cell index corresponding to the location of a set of points
 #' 
-#' return the cell index corresponding to the location of a set of points
+#' If the object has been cropped without normalization, then the indices return
+#' are relative to the original uncropped extent.  See \code{\link{st_crop}}
 #' @param x object of class \code{stars}
 #' @param sf object of class \code{sf} or \code{sfc}
 #' @examples

--- a/R/subset.R
+++ b/R/subset.R
@@ -194,6 +194,7 @@ st_intersects.bbox = function(x, y, ...) { # FIXME: segmentize first if geograph
 #' @param as_points logical; only relevant if \code{y} is of class \code{sf} or \code{sfc}: if \code{FALSE}, treat \code{x} as a set of points, else as a set of small polygons. Default: \code{TRUE} if \code{y} is two-dimensional, else \code{FALSE}; see Details
 #' @param ... ignored
 #' @param crop logical; if \code{TRUE}, the spatial extent of the returned object is cropped to still cover \code{obj}, if \code{FALSE}, the extent remains the same but cells outside \code{y} are given \code{NA} values.
+#' @param normalize logical; if \code{TRUE} then pass the cropped object to \code{\link{st_normalize}} before returning.
 #' @details for raster \code{x}, \code{st_crop} selects cells that intersect with \code{y}. 
 #' For intersection, are raster cells interpreted as points or as small polygons? 
 #' If \code{y} is of class \code{stars}, \code{x} raster cells are interpreted as points; if \code{y} is of class \code{bbox}, \code{x} cells are interpreted as cells (small polygons). Otherwise, if \code{as_points} is not given, cells are interpreted as points if \code{y} has a two-dimensional geometry.
@@ -250,7 +251,7 @@ st_intersects.bbox = function(x, y, ...) { # FIXME: segmentize first if geograph
 #' image(l7[bb,,,1], add = TRUE, col = sf.colors())
 #' plot(st_as_sfc(bb), add = TRUE, border = 'green', lwd = 2)
 st_crop.stars = function(x, y, ..., crop = TRUE, epsilon = sqrt(.Machine$double.eps), 
-		as_points = all(st_dimension(y) == 2, na.rm = TRUE)) {
+		as_points = all(st_dimension(y) == 2, na.rm = TRUE), normalize = FALSE) {
 	x = st_upfront(x) # put spatial dimensions up front; https://github.com/r-spatial/stars/issues/457
 	d = dim(x)
 	dm = st_dimensions(x)
@@ -307,6 +308,7 @@ st_crop.stars = function(x, y, ..., crop = TRUE, epsilon = sqrt(.Machine$double.
 		for (i in seq_along(x))
 			x[[i]][mask] = NA
 	}
+	if (normalize[1]) x = st_normalize(x)
 	x
 }
 

--- a/man/st_cells.Rd
+++ b/man/st_cells.Rd
@@ -12,7 +12,8 @@ st_cells(x, sf)
 \item{sf}{object of class \code{sf} or \code{sfc}}
 }
 \description{
-return the cell index corresponding to the location of a set of points
+If the object has been cropped without normalization, then the indices return
+are relative to the original uncropped extent.  See \code{\link{st_crop}}
 }
 \examples{
 set.seed(1345)

--- a/man/st_crop.Rd
+++ b/man/st_crop.Rd
@@ -21,7 +21,8 @@
   ...,
   crop = TRUE,
   epsilon = sqrt(.Machine$double.eps),
-  as_points = all(st_dimension(y) == 2, na.rm = TRUE)
+  as_points = all(st_dimension(y) == 2, na.rm = TRUE),
+  normalize = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,8 @@
 \item{collect}{logical; if \code{TRUE}, repeat cropping on \code{stars} object, i.e. after data has been read}
 
 \item{as_points}{logical; only relevant if \code{y} is of class \code{sf} or \code{sfc}: if \code{FALSE}, treat \code{x} as a set of points, else as a set of small polygons. Default: \code{TRUE} if \code{y} is two-dimensional, else \code{FALSE}; see Details}
+
+\item{normalize}{logical; if \code{TRUE} then pass the cropped object to \code{\link{st_normalize}} before returning.}
 }
 \description{
 crop a stars object


### PR DESCRIPTION
As per #685 this pull request adds a `normalize` argument (default is FALSE) to the `st_crop` function.

Here's a demonstration of the package with the changes.

``` r
suppressPackageStartupMessages({
  library(sf)
  library(stars)
  library(dplyr)
})
```

```         
## Warning: package 'sf' was built under R version 4.3.2
```

``` r
# read in data
filename= system.file(paste0("netcdf/", "avhrr-only-v2.19810901.nc"), package = "starsdata")
orig = read_stars(filename, sub = "sst", quiet = TRUE, proxy = FALSE)
bb = st_bbox(c(xmin = 270, ymin = 20, xmax = 300, ymax = 50), crs = st_crs(orig))
crop = st_crop(orig, bb, normalize = TRUE)
x = st_sample(bb, 10)
```

Compare the maximum cell index with the output of `st_cells`. Note the cells indices are less than the maximum possible cell index.

``` r
iorig = st_cells(orig, x)
iorig
```

```         
##  [1] 330876 353902 283381 289158 294893 264667 303586 343905 276140 270388
```

``` r
mx = prod(dim(orig))
cat("max orig index:", mx, "\n")
```

```         
## max orig index: 1036800
```

``` r
iorig <= mx
```

```         
##  [1] TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE
```

And now the same for the cropped.

``` r
icrop = st_cells(crop, x)
icrop
```

```         
##  [1]  8316 10222  4381  4878  5333  2827  6106  9465  3740  3268
```

``` r
mx = prod(dim(crop))
cat("max cropped index:", mx, "\n")
```

```         
## max cropped index: 14400
```

``` r
icrop <= mx
```

```         
##  [1] TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE TRUE
```
