### PR TITLE
Adapt internatl to_df function to work with sf tidyverse methods

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -1,6 +1,7 @@
 # convert arrays to data.frame, in long form
 to_df = function(x) {
-	dplyr::as_tibble(lapply(x, function(y) structure(y, dim = NULL)))
+	out = dplyr::as_tibble(lapply(x, function(y) structure(y, dim = NULL)))
+	if(any(sapply(out, inherits, "sfc")) st_as_sf(out) else out
 }
 
 set_dim = function(x, d) {

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -1,9 +1,7 @@
 # convert arrays to data.frame, in long form
 to_df = function(x) {
 	out = dplyr::as_tibble(lapply(x, function(y) structure(y, dim = NULL)))
-	if(any(sapply(out, inherits, "sfc")) {
-		sf::st_as_sf(out)
-	} else out
+	if(any(sapply(out, inherits, "sfc"))) sf::st_as_sf(out) else out
 }
 
 set_dim = function(x, d) {

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -1,7 +1,7 @@
 # convert arrays to data.frame, in long form
 to_df = function(x) {
 	out = dplyr::as_tibble(lapply(x, function(y) structure(y, dim = NULL)))
-	if(any(sapply(out, inherits, "sfc")) st_as_sf(out) else out
+	if(any(sapply(out, inherits, "sfc")) sf::st_as_sf(out) else out
 }
 
 set_dim = function(x, d) {

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -1,7 +1,9 @@
 # convert arrays to data.frame, in long form
 to_df = function(x) {
 	out = dplyr::as_tibble(lapply(x, function(y) structure(y, dim = NULL)))
-	if(any(sapply(out, inherits, "sfc")) sf::st_as_sf(out) else out
+	if(any(sapply(out, inherits, "sfc")) {
+		sf::st_as_sf(out)
+	} else out
 }
 
 set_dim = function(x, d) {


### PR DESCRIPTION
To have a sticky geometry behavior on stars objects with a geometry attribute the internal `to_df()` function could check if any sfc attribute is present. This would be helpful for the package [post](https://github.com/loreabad6/post) that I am building on top of stars. Alternatively, if this is too specific behavior, could `to_df()` be exported? Thanks!