### PR TITLE
fix macOS CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - {os: macos-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,6 +43,10 @@ jobs:
           use-public-rspm: true
           extra-repositories: "https://cran.uni-muenster.de/pebesma"
 
+      - name: Install macOS system dependencies
+        if: runner.os == 'macos'
+        run: brew install gdal proj
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck


### PR DESCRIPTION
sf 1.0.19 is downloaded from GitHub and needs to be compiled on macOS, so spatial libraries are needed for that.

Related to this commit: https://github.com/r-spatial/stars/commit/c5a2fe2c1a98b5815ebcf75812de7244f2e4f880