### PR TITLE
Add native support for geometry attribute

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -46,6 +46,7 @@ st_extract.stars = function(x, at, ..., bilinear = FALSE, time_column =
 		pts = at
 	else {
 		stopifnot(st_crs(at) == st_crs(x))
+		stopifnot(attr(at, "n_empty") == 0)
 		if (! all(st_dimension(at) == 0)) { # should check & branch here in case of MULTIPOINT?
 			stopifnot(is.null(time_column), !bilinear, !interpolate_time)
 			# from aggregate.stars_proxy:

--- a/R/rasterize.R
+++ b/R/rasterize.R
@@ -235,14 +235,10 @@ st_as_stars.data.frame = function(.x, ..., dims = coords, xy, y_decreasing = TRU
 		else 
 			c(NA_character_, NA_character_)
 	d = create_dimensions(dimensions, raster = get_raster(dimensions = raster_xy))
-	
 	l = lapply(.x[-dims], function(x) {
 			m = if (is.factor(x))
 					structure(factor(rep(NA_character_, prod(dim(d))), levels = levels(x)),
 							  dim = dim(d))
-				else if (inherits(x , "sfc"))
-					do.call("structure", list(.Data = array(NA, dim = dim(d)),
-							... = append(attributes(x), list(dim = dim(d)))))
 				else 
 					array(NA, dim = dim(d))
 			m[index] = x # match order

--- a/R/rasterize.R
+++ b/R/rasterize.R
@@ -200,7 +200,7 @@ st_as_stars.data.frame = function(.x, ..., dims = coords, xy, y_decreasing = TRU
 			stop("xy coordinates not found in data")
 	}
 	stopifnot(length(dims) >= 1, all(dims >= 1), !any(is.na(dims)))
-
+	
 	index = NULL
 	dimensions = list()
 	this_dim = 1
@@ -235,14 +235,24 @@ st_as_stars.data.frame = function(.x, ..., dims = coords, xy, y_decreasing = TRU
 		else 
 			c(NA_character_, NA_character_)
 	d = create_dimensions(dimensions, raster = get_raster(dimensions = raster_xy))
+	
 	l = lapply(.x[-dims], function(x) {
 			m = if (is.factor(x))
 					structure(factor(rep(NA_character_, prod(dim(d))), levels = levels(x)),
-						dim = dim(d))
+							  dim = dim(d))
+				else if (inherits(x , "sfc"))
+					do.call("structure", list(.Data = array(NA, dim = dim(d)),
+							... = append(attributes(x), list(dim = dim(d)))))
 				else 
 					array(NA, dim = dim(d))
 			m[index] = x # match order
-			m 
+			if(inherits(x, "sfc")) 
+				array(
+					st_sfc(m, crs = st_crs(x), precision = st_precision(x)),
+					dim = dim(d)
+				)
+			else 
+				m 
 		}
 	)
 	st_stars(l, d)


### PR DESCRIPTION
In [loreabad6/post](https://github.com/loreabad6/post) the function `as_post_array()` takes care of the data cube creation, but probably in a redundant way of what is offered by `st_as_stars.data.frame()`. Supporting this directly with stars, this PR passes the geometries as an array instead of as a list which was the previous behaviour. 

``` r
library(stars)
date = seq(
    from = as.Date("2020-10-01"),
    to = as.Date("2020-10-05"),
    length.out = 5
)
geom = st_sample(st_bbox(c(xmin = 0, xmax = 1, ymin = 0, ymax = 0)), 25)
df = st_sf(id = rep(letters[1:5], each = 5), date = date, geom)
st_as_stars(df, dims = c("id", "date"))
#> stars object with 2 dimensions and 1 attribute
#> attribute(s):
#>      geom    
#>  POINT  :25  
#>  epsg:NA: 0  
#> dimension(s):
#>      from to     offset  delta refsys  values
#> id      1  5         NA     NA     NA a,...,e
#> date    1  5 2020-10-01 1 days   Date    NULL
```